### PR TITLE
Async support for MCTP trait implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ version = "0.2.0"
 dependencies = [
  "libc",
  "mctp",
+ "smol",
 ]
 
 [[package]]

--- a/mctp-linux/Cargo.toml
+++ b/mctp-linux/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["network-programming", "embedded", "hardware-support", "os::linux-
 [dependencies]
 libc = "0.2"
 mctp = { workspace = true, features = ["std"] }
+smol = { version = "2.0" }
 
 [[example]]
 name = "mctp-req"

--- a/mctp-linux/examples/async-req.rs
+++ b/mctp-linux/examples/async-req.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * Simple MCTP example using Linux sockets in async mode.
+ *
+ * Copyright (c) 2025 Code Construct
+ */
+
+use mctp::{AsyncReqChannel, Eid, MCTP_TYPE_CONTROL};
+use mctp_linux::MctpLinuxAsyncReq;
+
+fn main() -> std::io::Result<()> {
+    const EID: Eid = Eid(8);
+
+    let mut ep = MctpLinuxAsyncReq::new(EID, None)?;
+
+    let tx_buf = vec![0x02u8];
+    let mut rx_buf = vec![0u8; 16];
+
+    let (typ, ic, rx_buf) = smol::block_on(async {
+        ep.send(MCTP_TYPE_CONTROL, &tx_buf).await?;
+        ep.recv(&mut rx_buf).await
+    })?;
+
+    println!("response type {typ}, ic {ic:?}: {rx_buf:x?}");
+
+    Ok(())
+}

--- a/mctp-linux/src/lib.rs
+++ b/mctp-linux/src/lib.rs
@@ -797,4 +797,17 @@ impl MctpAddr {
     pub fn create_listener(&self, typ: MsgType) -> Result<MctpLinuxListener> {
         MctpLinuxListener::new(typ, self.net)
     }
+
+    /// Create an `MctpLinuxAsyncReq` using the net & eid values in this address.
+    pub fn create_req_async(&self) -> Result<MctpLinuxAsyncReq> {
+        MctpLinuxAsyncReq::new(self.eid, self.net)
+    }
+
+    /// Create an `MctpLinuxAsyncListener`.
+    pub fn create_listener_async(
+        &self,
+        typ: MsgType,
+    ) -> Result<MctpLinuxAsyncListener> {
+        MctpLinuxAsyncListener::new(typ, self.net)
+    }
 }


### PR DESCRIPTION
This series adds implementations of the async `mctp` traits for the Linux sockets transport