### PR TITLE
`Cargo.toml` cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,20 @@ mctp-estack = { version = "0.1", path = "mctp-estack" }
 pldm = { version = "0.2", path = "pldm", default-features = false }
 pldm-fw = { version = "0.2", path = "pldm-fw", default-features = false }
 
-embedded-io-async = "0.6"
-embedded-io-adapters = "0.6"
+anyhow = "1.0.80"
+argh = "0.1.12"
+chrono = { version = "0.4", default-features = false }
+crc = "3.0"
 defmt = "0.3"
+embedded-io-adapters = { version = "0.6", features = ["std", "futures-03"] }
+embedded-io-async = "0.6"
+enumset = "1.1"
+env_logger = "0.11.3"
+heapless = "0.8"
+log = "0.4"
+num-derive = { version = "0.4", default-features = false }
+num-traits = { version = "0.2", default-features = false }
+proptest = "1.0.0"
+simplelog = "0.12"
+smol = "2.0"
+uuid = { version = "1.16.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/CodeConstruct/mctp-rs"
 
 [workspace.dependencies]
-mctp = { version = "0.2", path = "mctp", default-features = false }
-mctp-linux = { version = "0.2", path = "mctp-linux" }
-mctp-estack = { version = "0.1", path = "mctp-estack" }
-pldm = { version = "0.2", path = "pldm", default-features = false }
-pldm-fw = { version = "0.2", path = "pldm-fw", default-features = false }
-
 anyhow = "1.0.80"
 argh = "0.1.12"
 chrono = { version = "0.4", default-features = false }
@@ -26,8 +20,13 @@ enumset = "1.1"
 env_logger = "0.11.3"
 heapless = "0.8"
 log = "0.4"
+mctp-estack = { version = "0.1", path = "mctp-estack" }
+mctp-linux = { version = "0.2", path = "mctp-linux" }
+mctp = { version = "0.2", path = "mctp", default-features = false }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+pldm-fw = { version = "0.2", path = "pldm-fw", default-features = false }
+pldm = { version = "0.2", path = "pldm", default-features = false }
 proptest = "1.0.0"
 simplelog = "0.12"
 smol = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ members = [ "pldm-fw-cli", "standalone" ]
 exclude = [ "mctp-usb-embassy" ]
 resolver = "2"
 
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/CodeConstruct/mctp-rs"
+
 [workspace.dependencies]
 mctp = { version = "0.2", path = "mctp", default-features = false }
 mctp-linux = { version = "0.2", path = "mctp-linux" }

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -9,25 +9,25 @@ categories = ["network-programming", "embedded", "hardware-support", "no-std"]
 rust-version = "1.82"
 
 [dependencies]
-mctp = { workspace = true }
-heapless = { workspace = true }
-log = { workspace = true, optional = true }
 crc = { workspace = true }
-embedded-io-async = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-sync = "0.7"
+embedded-io-async = { workspace = true }
+heapless = { workspace = true }
+log = { workspace = true, optional = true }
+mctp = { workspace = true }
 smbus-pec = { version = "1.0", features = ["lookup-table"] }
 uuid = { workspace = true }
+
+[dev-dependencies]
+embedded-io-adapters = { workspace = true }
+env_logger =  { workspace = true }
+proptest = { workspace = true }
+simplelog = { workspace = true }
+smol = { workspace = true }
 
 [features]
 default = ["log"]
 std = ["mctp/std"]
 log = ["dep:log"]
 defmt = ["mctp/defmt", "dep:defmt" ]
-
-[dev-dependencies]
-proptest = { workspace = true }
-embedded-io-adapters = { workspace = true }
-simplelog = { workspace = true }
-env_logger =  { workspace = true }
-smol = { workspace = true }

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -9,15 +9,15 @@ categories = ["network-programming", "embedded", "hardware-support", "no-std"]
 rust-version = "1.82"
 
 [dependencies]
-mctp.workspace = true
-heapless = "0.8"
-log = { version = "0.4", optional = true }
-crc = "3"
+mctp = { workspace = true }
+heapless = { workspace = true }
+log = { workspace = true, optional = true }
+crc = { workspace = true }
 embedded-io-async = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-sync = "0.7"
 smbus-pec = { version = "1.0", features = ["lookup-table"] }
-uuid = { version = "1.16.0", default-features = false }
+uuid = { workspace = true }
 
 [features]
 default = ["log"]
@@ -26,8 +26,8 @@ log = ["dep:log"]
 defmt = ["mctp/defmt", "dep:defmt" ]
 
 [dev-dependencies]
-proptest = "1.0.0"
-embedded-io-adapters = { workspace = true, features = ["std", "futures-03"] }
-simplelog = "0.12"
-env_logger = "0.11"
-smol = "2.0"
+proptest = { workspace = true }
+embedded-io-adapters = { workspace = true }
+simplelog = { workspace = true }
+env_logger =  { workspace = true }
+smol = { workspace = true }

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -2,9 +2,9 @@
 name = "mctp-estack"
 description = "Embedded MCTP stack"
 version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support", "no-std"]
 rust-version = "1.82"
 

--- a/mctp-linux/Cargo.toml
+++ b/mctp-linux/Cargo.toml
@@ -2,9 +2,9 @@
 name = "mctp-linux"
 description = "Management Component Transport Protocol (MCTP) Linux transport"
 version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support", "os::linux-apis"]
 
 [dependencies]

--- a/mctp-linux/Cargo.toml
+++ b/mctp-linux/Cargo.toml
@@ -9,8 +9,8 @@ categories = ["network-programming", "embedded", "hardware-support", "os::linux-
 
 [dependencies]
 libc = "0.2"
-mctp = { workspace = true, features = ["std"] }
-smol = { version = "2.0" }
+mctp = { workspace = true }
+smol = { workspace = true }
 
 [[example]]
 name = "mctp-req"

--- a/mctp-usb-embassy/Cargo.toml
+++ b/mctp-usb-embassy/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "mctp-usb-embassy"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-categories = ["network-programming", "embedded", "no-std"]
-repository = "https://github.com/CodeConstruct/mctp-rs"
-rust-version = "1.82"
 description = "MCTP over USB transport for embassy-usb"
+edition = "2021"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/CodeConstruct/mctp-rs"
+categories = ["network-programming", "embedded", "no-std"]
+rust-version = "1.82"
 
 [dependencies]
 embassy-usb = { version = "0.5" }

--- a/mctp-usb-embassy/Cargo.toml
+++ b/mctp-usb-embassy/Cargo.toml
@@ -9,16 +9,14 @@ categories = ["network-programming", "embedded", "no-std"]
 rust-version = "1.82"
 
 [dependencies]
-embassy-usb = { version = "0.5" }
-embassy-usb-driver = { version = "0.2" }
-embassy-futures = { version = "0.1" }
-
-log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
-
-mctp = { version = "0.2", path = "../mctp", default-features = false }
-mctp-estack = { version = "0.1", path = "../mctp-estack", default-features = false }
+embassy-futures = { version = "0.1" }
+embassy-usb-driver = { version = "0.2" }
+embassy-usb = { version = "0.5" }
 heapless = "0.8"
+log = { version = "0.4", optional = true }
+mctp-estack = { version = "0.1", path = "../mctp-estack", default-features = false }
+mctp = { version = "0.2", path = "../mctp", default-features = false }
 
 [features]
 default = ["log"]

--- a/mctp/Cargo.toml
+++ b/mctp/Cargo.toml
@@ -2,9 +2,9 @@
 name = "mctp"
 description = "Management Component Transport Protocol (MCTP) base types and traits"
 version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support", "no-std"]
 
 [dependencies]

--- a/pldm-fw-cli/Cargo.toml
+++ b/pldm-fw-cli/Cargo.toml
@@ -8,13 +8,12 @@ repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support", "command-line-utilities"]
 
 [dependencies]
-pldm-fw = { workspace = true, features = ["std"] }
-mctp-linux = { workspace = true }
-mctp = { workspace = true }
-
-argh = { workspace = true}
 anyhow = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
+argh = { workspace = true}
 chrono = { workspace = true, features = ["clock"] }
 enumset = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+mctp-linux = { workspace = true }
+mctp = { workspace = true }
+pldm-fw = { workspace = true, features = ["std"] }

--- a/pldm-fw-cli/Cargo.toml
+++ b/pldm-fw-cli/Cargo.toml
@@ -12,9 +12,9 @@ pldm-fw = { workspace = true, features = ["std"] }
 mctp-linux = { workspace = true }
 mctp = { workspace = true }
 
-argh = "0.1.12"
-anyhow = "1.0.80"
-env_logger = "0.11.3"
-log = "0.4"
-chrono = {version = "0.4", default-features = false, features = ["clock"] }
-enumset = "1.1"
+argh = { workspace = true}
+anyhow = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
+enumset = { workspace = true }

--- a/pldm-fw-cli/Cargo.toml
+++ b/pldm-fw-cli/Cargo.toml
@@ -2,9 +2,9 @@
 name = "pldm-fw-cli"
 description = "Platform Level Data Model (PLDM) for Firmware utilities"
 version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support", "command-line-utilities"]
 
 [dependencies]

--- a/pldm-fw/Cargo.toml
+++ b/pldm-fw/Cargo.toml
@@ -8,18 +8,18 @@ repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
-pldm = { workspace = true }
+chrono = { workspace = true }
+crc = { workspace = true }
+enumset = { workspace = true }
+heapless = { workspace = true }
+log = { workspace = true }
 mctp = { workspace = true }
 nom = { version = "7.1", default-features = false }
-chrono = { workspace = true }
-enumset = { workspace = true }
-uuid = { workspace = true, features = ["v1"] }
-thiserror = { version = "1.0", optional = true }
-log = { workspace = true }
-crc = { workspace = true }
-heapless = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
+pldm = { workspace = true }
+thiserror = { version = "1.0", optional = true }
+uuid = { workspace = true, features = ["v1"] }
 
 [features]
 default = ["std"]

--- a/pldm-fw/Cargo.toml
+++ b/pldm-fw/Cargo.toml
@@ -2,9 +2,9 @@
 name = "pldm-fw"
 description = "Platform Level Data Model (PLDM) for Firmware Update library"
 version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]

--- a/pldm-fw/Cargo.toml
+++ b/pldm-fw/Cargo.toml
@@ -11,15 +11,15 @@ categories = ["network-programming", "embedded", "hardware-support"]
 pldm = { workspace = true }
 mctp = { workspace = true }
 nom = { version = "7.1", default-features = false }
-chrono = {version = "0.4", default-features = false }
-enumset = "1.1"
-uuid = { version = "1.3", features = ["v1"], default-features = false }
+chrono = { workspace = true }
+enumset = { workspace = true }
+uuid = { workspace = true, features = ["v1"] }
 thiserror = { version = "1.0", optional = true }
-log = "0.4"
-crc = "3.0"
-heapless = "0.8"
-num-derive = { version = "0.4", default-features = false }
-num-traits = { version = "0.2", default-features = false }
+log = { workspace = true }
+crc = { workspace = true }
+heapless = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 
 [features]
 default = ["std"]

--- a/pldm/Cargo.toml
+++ b/pldm/Cargo.toml
@@ -2,9 +2,9 @@
 name = "pldm"
 description = "Platform Level Data Model (PLDM) base types and functions"
 version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]

--- a/pldm/Cargo.toml
+++ b/pldm/Cargo.toml
@@ -9,8 +9,8 @@ categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
 mctp = { workspace = true }
-num-traits = { version = "0.2", default-features = false }
-num-derive = { version = "0.4", default-features = false }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 
 [features]
 default = ["std"]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -2,9 +2,9 @@
 name = "mctp-standalone"
 description = "Standalone MCTP over serial"
 version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming"]
 
 [dependencies]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -8,21 +8,19 @@ repository.workspace = true
 categories = ["network-programming"]
 
 [dependencies]
-mctp = { workspace = true }
-mctp-estack = { workspace = true }
-
-log = { workspace = true }
 embedded-io-async = { workspace = true }
+log = { workspace = true }
+mctp-estack = { workspace = true }
+mctp = { workspace = true }
 smol = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 argh = { workspace = true}
-simplelog = { workspace = true }
 embedded-io-adapters = { workspace = true }
 getrandom = "0.2"
-
 proptest = { workspace = true }
+simplelog = { workspace = true }
 
 [features]
 std = ["mctp/std", "embedded-io-adapters/std"]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -8,21 +8,21 @@ repository.workspace = true
 categories = ["network-programming"]
 
 [dependencies]
-mctp = { workspace = true, features = ["std"] }
+mctp = { workspace = true }
 mctp-estack = { workspace = true }
 
-log = "0.4"
+log = { workspace = true }
 embedded-io-async = { workspace = true }
-smol = "2.0"
+smol = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0"
-argh = "0.1"
-simplelog = "0.12"
-embedded-io-adapters = { workspace = true, features = ["std", "futures-03"] }
+anyhow = { workspace = true }
+argh = { workspace = true}
+simplelog = { workspace = true }
+embedded-io-adapters = { workspace = true }
 getrandom = "0.2"
 
-proptest = "1.0.0"
+proptest = { workspace = true }
 
 [features]
 std = ["mctp/std", "embedded-io-adapters/std"]


### PR DESCRIPTION
Best reviewed one commit at a time.

The first two commits are about not repeating information. (Nb: why isn't mctp-usb-embassy part of the workspace?)

The third commit addresses a pet peeve of mine, one that not everyone shares.