### PR TITLE
Move mctp-usb-embassy into the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-futures"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+
+[[package]]
+name = "embassy-net-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
+
+[[package]]
+name = "embassy-net-driver-channel"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a567ab50319d866ad5e6c583ed665ba9b07865389644d3d82e45bf1497c934"
+dependencies = [
+ "embassy-futures",
+ "embassy-net-driver",
+ "embassy-sync",
+]
+
+[[package]]
 name = "embassy-sync"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +494,29 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "heapless",
+]
+
+[[package]]
+name = "embassy-usb"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb69c7ca7fa90b9ae590e3dea985ef80df06d900a350f9cc9d3f3c8113fc4370"
+dependencies = [
+ "embassy-futures",
+ "embassy-net-driver-channel",
+ "embassy-sync",
+ "embassy-usb-driver",
+ "embedded-io-async",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-usb-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17119855ccc2d1f7470a39756b12068454ae27a3eabb037d940b5c03d9c77b7a"
+dependencies = [
+ "embedded-io-async",
 ]
 
 [[package]]
@@ -843,6 +889,20 @@ dependencies = [
  "proptest",
  "simplelog",
  "smol",
+]
+
+[[package]]
+name = "mctp-usb-embassy"
+version = "0.1.0"
+dependencies = [
+ "defmt",
+ "embassy-futures",
+ "embassy-usb",
+ "embassy-usb-driver",
+ "heapless",
+ "log",
+ "mctp",
+ "mctp-estack",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = [ "pldm-fw-cli", "standalone" ]
-exclude = [ "mctp-usb-embassy" ]
+members = [ "mctp-usb-embassy", "pldm-fw-cli", "standalone" ]
 resolver = "2"
 
 [workspace.package]
@@ -20,7 +19,7 @@ enumset = "1.1"
 env_logger = "0.11.3"
 heapless = "0.8"
 log = "0.4"
-mctp-estack = { version = "0.1", path = "mctp-estack" }
+mctp-estack = { version = "0.1", path = "mctp-estack", default-features = false }
 mctp-linux = { version = "0.2", path = "mctp-linux" }
 mctp = { version = "0.2", path = "mctp", default-features = false }
 num-derive = { version = "0.4", default-features = false }

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -30,19 +30,18 @@ for c in $NOSTD_CRATES; do
     )
 done
 
-# mctp-estack combinations
+# mctp-estack combinations, defmt and log
 (
 cd mctp-estack
 cargo build --target thumbv7em-none-eabihf --features defmt --no-default-features
 cargo build --features log
 )
 
-# not a workspace
+# mctp-usb-embassy combinations, defmt and log
 (
 cd mctp-usb-embassy
 cargo build --target thumbv7em-none-eabihf --features defmt --no-default-features
 cargo build --features log
-cargo doc
 )
 
 cargo doc --features mctp-estack/log

--- a/mctp-usb-embassy/Cargo.toml
+++ b/mctp-usb-embassy/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "mctp-usb-embassy"
 description = "MCTP over USB transport for embassy-usb"
-edition = "2021"
 version = "0.1.0"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/CodeConstruct/mctp-rs"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 categories = ["network-programming", "embedded", "no-std"]
 rust-version = "1.82"
 
 [dependencies]
-defmt = { version = "0.3", optional = true }
+defmt = { workspace = true, optional = true }
 embassy-futures = { version = "0.1" }
 embassy-usb-driver = { version = "0.2" }
-embassy-usb = { version = "0.5" }
-heapless = "0.8"
-log = { version = "0.4", optional = true }
-mctp-estack = { version = "0.1", path = "../mctp-estack", default-features = false }
-mctp = { version = "0.2", path = "../mctp", default-features = false }
+embassy-usb = { version = "0.5", default-features = false }
+heapless = { workspace = true }
+log = { workspace = true, optional = true }
+mctp-estack = { workspace = true }
+mctp = { workspace = true, default-features = false }
 
 [features]
 default = ["log"]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming"]
 [dependencies]
 embedded-io-async = { workspace = true }
 log = { workspace = true }
-mctp-estack = { workspace = true }
+mctp-estack = { workspace = true, default-features = true }
 mctp = { workspace = true }
 smol = { workspace = true }
 


### PR DESCRIPTION
mctp-usb-embassy now sets `default-features = false` for usb-embassy, to avoid pulling in usbd-hid feature which previously prevented builds (via ssmarshal
https://gitlab.com/robigalia/ssmarshal/-/issues/5).

mctp-estack workspace dependency is now `default-features = false`.