### PR TITLE
PLDM File Transfer protocol implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +468,7 @@ name = "deku"
 version = "0.19.1"
 source = "git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3#d68915c71e1b3ac76726328803eeffc773fb9871"
 dependencies = [
+ "bitvec",
  "deku_derive",
  "no_std_io2",
  "rustversion",
@@ -659,6 +672,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1076,6 +1095,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pldm-platform"
+version = "0.1.0"
+dependencies = [
+ "deku",
+ "heapless",
+ "log",
+ "mctp",
+ "num-derive",
+ "num-traits",
+ "pldm",
+]
+
+[[package]]
 name = "polling"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1202,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1367,6 +1405,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1658,6 +1702,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ source = "git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2F
 dependencies = [
  "bitvec",
  "deku_derive",
+ "log",
  "no_std_io2",
  "rustversion",
 ]
@@ -875,9 +876,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mctp"
@@ -1105,6 +1106,21 @@ dependencies = [
  "num-derive",
  "num-traits",
  "pldm",
+]
+
+[[package]]
+name = "pldm-platform-util"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "argh",
+ "deku",
+ "env_logger",
+ "log",
+ "mctp",
+ "mctp-linux",
+ "pldm-platform",
+ "smol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,12 +1070,14 @@ dependencies = [
  "crc",
  "deku",
  "enumset",
+ "env_logger",
  "log",
  "mctp",
  "mctp-linux",
  "num-derive",
  "num-traits",
  "pldm",
+ "pldm-platform",
  "smol",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn",
 ]
 
@@ -448,6 +449,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3983b127f13995e68c1e29071e5d115cd96f215ccb5e6812e3728cd6f92653b3"
 dependencies = [
  "thiserror 2.0.11",
+]
+
+[[package]]
+name = "deku"
+version = "0.19.1"
+source = "git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3#d68915c71e1b3ac76726328803eeffc773fb9871"
+dependencies = [
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.19.1"
+source = "git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3#d68915c71e1b3ac76726328803eeffc773fb9871"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -918,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2b9acd47481ab557a89a5665891be79e43cce8a29ad77aa9419d7be5a7c06a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1033,9 @@ dependencies = [
 name = "pldm"
 version = "0.2.0"
 dependencies = [
+ "crc",
+ "deku",
+ "heapless",
  "mctp",
  "num-derive",
  "num-traits",
@@ -1218,6 +1252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1349,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,13 +1066,16 @@ dependencies = [
 name = "pldm-file"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "crc",
  "deku",
  "log",
  "mctp",
+ "mctp-linux",
  "num-derive",
  "num-traits",
  "pldm",
+ "smol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pldm-file"
+version = "0.1.0"
+dependencies = [
+ "crc",
+ "deku",
+ "log",
+ "mctp",
+ "num-derive",
+ "num-traits",
+ "pldm",
+]
+
+[[package]]
 name = "pldm-fw"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "crc",
  "deku",
  "heapless",
+ "log",
  "mctp",
  "num-derive",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "anyhow",
  "crc",
  "deku",
+ "enumset",
  "log",
  "mctp",
  "mctp-linux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "mctp-usb-embassy", "pldm-fw-cli", "pldm-platform", "pldm-platform-util", "standalone" ]
+members = [ "mctp-usb-embassy", "pldm-file", "pldm-fw-cli", "pldm-platform", "pldm-platform-util", "standalone" ]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "mctp-usb-embassy", "pldm-fw-cli", "standalone" ]
+members = [ "mctp-usb-embassy", "pldm-fw-cli", "pldm-platform", "standalone" ]
 resolver = "2"
 
 [workspace.package]
@@ -26,6 +26,7 @@ mctp = { version = "0.2", path = "mctp", default-features = false }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 pldm-fw = { version = "0.2", path = "pldm-fw", default-features = false }
+pldm-platform = { path = "pldm-platform", default-features = false }
 pldm = { version = "0.2", path = "pldm", default-features = false }
 proptest = "1.0.0"
 simplelog = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ argh = "0.1.12"
 chrono = { version = "0.4", default-features = false }
 crc = "3.0"
 defmt = "0.3"
+deku = { git = "https://github.com/CodeConstruct/deku.git", tag = "cc/deku-v0.19.1/no-alloc-3", default-features = false }
 embedded-io-adapters = { version = "0.6", features = ["std", "futures-03"] }
 embedded-io-async = "0.6"
 enumset = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "mctp-usb-embassy", "pldm-fw-cli", "pldm-platform", "standalone" ]
+members = [ "mctp-usb-embassy", "pldm-fw-cli", "pldm-platform", "pldm-platform-util", "standalone" ]
 resolver = "2"
 
 [workspace.package]

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -26,7 +26,14 @@ NOSTD_CRATES="mctp pldm pldm-fw"
 for c in $NOSTD_CRATES; do
     (
     cd $c
-    cargo build --target thumbv7em-none-eabihf --no-default-features --release
+    cargo build --target thumbv7em-none-eabihf --no-default-features
+    )
+done
+ALLOC_CRATES="pldm"
+for c in $ALLOC_CRATES; do
+    (
+    cd $c
+    cargo build --target thumbv7em-none-eabihf --no-default-features --features alloc
     )
 done
 

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -22,14 +22,14 @@ cargo build --release
 cargo test
 
 # stable, no_std
-NOSTD_CRATES="mctp pldm pldm-fw"
+NOSTD_CRATES="mctp pldm pldm-fw pldm-platform"
 for c in $NOSTD_CRATES; do
     (
     cd $c
     cargo build --target thumbv7em-none-eabihf --no-default-features
     )
 done
-ALLOC_CRATES="pldm"
+ALLOC_CRATES="pldm pldm-platform"
 for c in $ALLOC_CRATES; do
     (
     cd $c

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -22,14 +22,14 @@ cargo build --release
 cargo test
 
 # stable, no_std
-NOSTD_CRATES="mctp pldm pldm-fw pldm-platform"
+NOSTD_CRATES="mctp pldm pldm-fw pldm-platform pldm-file"
 for c in $NOSTD_CRATES; do
     (
     cd $c
     cargo build --target thumbv7em-none-eabihf --no-default-features
     )
 done
-ALLOC_CRATES="pldm pldm-platform"
+ALLOC_CRATES="pldm pldm-platform pldm-file"
 for c in $ALLOC_CRATES; do
     (
     cd $c

--- a/mctp-estack/src/control.rs
+++ b/mctp-estack/src/control.rs
@@ -515,7 +515,7 @@ impl<'a> MctpControl<'a> {
                 let res = self.router.set_eid(eid).await;
                 let present_eid = self.router.get_eid().await;
 
-                if res.is_ok() && old != present_eid {
+                if res.is_ok() {
                     event = Some(ControlEvent::SetEndpointId {
                         old,
                         new: present_eid,
@@ -550,9 +550,12 @@ impl<'a> MctpControl<'a> {
 
 /// An MCTP control handler event
 pub enum ControlEvent {
-    /// Set Endpoint ID changed EID
+    /// Set Endpoint ID received.
+    ///
+    /// Note that the EID may be unchanged.
     SetEndpointId {
-        /// Previous EID
+        /// Previous EID.
+        ///
         old: Eid,
         /// New EID
         new: Eid,

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -25,13 +25,17 @@
 //! `mctp-estack` uses fixed sizes to be suitable on no-alloc platforms.
 //! These can be configured at build time, see [`config`]
 
-#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![allow(clippy::int_plus_one)]
 #![allow(clippy::too_many_arguments)]
 // defmt does not currently allow inline format arguments, so we don't want
 // those reworked when using the log crate either.
 #![allow(clippy::uninlined_format_args)]
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
 
 /// Re-exported so that callers can use the same `heapless` version.
 ///

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -585,16 +585,21 @@ impl Stack {
         trace!("set flow {}", peer);
 
         if let Some(tv) = tag {
+            if flow_expires {
+                trace!("Can't specify a tag with tag_expires");
+                return Err(Error::BadArgument);
+            }
+
+            // Compare with any existing flow
             if let Some(f) = self.flows.get_mut(&(peer, tv)) {
-                if f.expiry_stamp.is_some() {
-                    // An Owned tag given to start_send() must have been initially created
-                    // tag_expires=false.
-                    trace!("Can't specify an owned tag that didn't have tag_expires=false");
+                if flow_expires != f.expiry_stamp.is_some() {
+                    trace!("varying slow_expires for flow");
                     return Err(Error::BadArgument);
                 }
 
                 if f.cookie != cookie {
-                    trace!("varying app for flow");
+                    trace!("varying cookie for flow");
+                    return Err(Error::BadArgument);
                 }
                 return Ok(tv);
             }

--- a/mctp/src/lib.rs
+++ b/mctp/src/lib.rs
@@ -5,8 +5,7 @@
  * Copyright (c) 2024 Code Construct
  */
 
-// Tests may use std
-#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["network-programming", "embedded", "hardware-support"]
 [dependencies]
 crc = { workspace = true }
 deku = { workspace = true }
+enumset = { workspace = true }
 log = { workspace = true }
 mctp = { workspace = true }
 num-derive = { workspace = true }

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pldm-file"
+description = "Platform Level Data Model (PLDM) for File Transfer"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+categories = ["network-programming", "embedded", "hardware-support"]
+
+[dependencies]
+crc = { workspace = true }
+deku = { workspace = true }
+log = { workspace = true }
+mctp = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+pldm = { workspace = true }
+
+[features]
+default = ["std"]
+alloc = ["pldm/alloc", "deku/alloc"]
+std = ["alloc", "pldm/std", "mctp/std"]

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -20,7 +20,9 @@ pldm = { workspace = true }
 [dev-dependencies]
 anyhow = "1.0"
 mctp-linux = { workspace = true }
+pldm-platform = { workspace = true, features = ["alloc"] }
 smol = "2.0"
+env_logger = "0.11.3"
 
 [features]
 default = ["std"]

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -28,3 +28,11 @@ env_logger = "0.11.3"
 default = ["std"]
 alloc = ["pldm/alloc", "deku/alloc"]
 std = ["alloc", "pldm/std", "mctp/std"]
+
+[[example]]
+name = "pldm-file-host"
+path = "examples/host.rs"
+
+[[example]]
+name = "pldm-file-client"
+path = "examples/client.rs"

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -16,6 +16,11 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 pldm = { workspace = true }
 
+[dev-dependencies]
+anyhow = "1.0"
+mctp-linux = { workspace = true }
+smol = "2.0"
+
 [features]
 default = ["std"]
 alloc = ["pldm/alloc", "deku/alloc"]

--- a/pldm-file/examples/client.rs
+++ b/pldm-file/examples/client.rs
@@ -1,0 +1,39 @@
+use anyhow::{Context, Result};
+use mctp::Eid;
+use mctp_linux::MctpLinuxAsyncReq;
+use pldm_file::{
+    client::{df_open, df_properties, df_read},
+    proto::{DfOpenAttributes, DfProperty, FileIdentifier},
+};
+
+const EID: Eid = Eid(8);
+
+fn main() -> Result<()> {
+    let mut req = MctpLinuxAsyncReq::new(EID, None)?;
+
+    let (mcm_prop, fds_prop) = smol::block_on(async {
+        (
+            df_properties(&mut req, DfProperty::MaxConcurrentMedium).await,
+            df_properties(&mut req, DfProperty::MaxFileDescriptors).await,
+        )
+    });
+
+    println!("Max Concurrent Medium: {mcm_prop:?}, Max FDs: {fds_prop:?}");
+
+    smol::block_on(async {
+        let id = FileIdentifier(0);
+        let attrs = DfOpenAttributes::empty();
+        let fd = df_open(&mut req, id, attrs)
+            .await
+            .context("DfOpen failed")?;
+
+        println!("Open: {fd:?}");
+
+        let mut buf = vec![0; 4096];
+        let res = df_read(&mut req, fd, 0, &mut buf).await;
+
+        println!("Read: {res:?}");
+
+        Ok(())
+    })
+}

--- a/pldm-file/examples/client.rs
+++ b/pldm-file/examples/client.rs
@@ -3,8 +3,8 @@ use mctp::Eid;
 use mctp_linux::MctpLinuxAsyncReq;
 use pldm::control::requester::negotiate_transfer_parameters;
 use pldm_file::{
-    client::{df_open, df_properties, df_read},
-    proto::{DfOpenAttributes, DfProperty, FileIdentifier},
+    client::{df_close, df_open, df_properties, df_read},
+    proto::{DfCloseAttributes, DfOpenAttributes, DfProperty, FileIdentifier},
 };
 
 const EID: Eid = Eid(8);
@@ -40,6 +40,11 @@ fn main() -> Result<()> {
         let res = df_read(&mut req, fd, 0, &mut buf).await;
 
         println!("Read: {res:?}");
+
+        let attrs = DfCloseAttributes::empty();
+        let res = df_close(&mut req, fd, attrs).await;
+
+        println!("Close: {res:?}");
 
         Ok(())
     })

--- a/pldm-file/examples/client.rs
+++ b/pldm-file/examples/client.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use mctp::Eid;
 use mctp_linux::MctpLinuxAsyncReq;
+use pldm::control::requester::negotiate_transfer_parameters;
 use pldm_file::{
     client::{df_open, df_properties, df_read},
     proto::{DfOpenAttributes, DfProperty, FileIdentifier},
@@ -11,16 +12,22 @@ const EID: Eid = Eid(8);
 fn main() -> Result<()> {
     let mut req = MctpLinuxAsyncReq::new(EID, None)?;
 
-    let (mcm_prop, fds_prop) = smol::block_on(async {
-        (
-            df_properties(&mut req, DfProperty::MaxConcurrentMedium).await,
-            df_properties(&mut req, DfProperty::MaxFileDescriptors).await,
-        )
-    });
-
-    println!("Max Concurrent Medium: {mcm_prop:?}, Max FDs: {fds_prop:?}");
-
     smol::block_on(async {
+        let mcm_prop =
+            df_properties(&mut req, DfProperty::MaxConcurrentMedium).await;
+        let fds_prop =
+            df_properties(&mut req, DfProperty::MaxFileDescriptors).await;
+        println!("Max Concurrent Medium: {mcm_prop:?}, Max FDs: {fds_prop:?}");
+
+        let req_types = [pldm_file::PLDM_TYPE_FILE_TRANSFER];
+        let mut buf = [0u8];
+
+        let (size, neg_types) =
+            negotiate_transfer_parameters(&mut req, &req_types, &mut buf, 512)
+                .await?;
+
+        println!("Negotiated multipart size {size} for types {neg_types:?}");
+
         let id = FileIdentifier(0);
         let attrs = DfOpenAttributes::empty();
         let fd = df_open(&mut req, id, attrs)

--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -1,24 +1,29 @@
-use anyhow::{Context, Result};
-use log::warn;
-use mctp::AsyncListener;
+use anyhow::{bail, Context, Result};
+use deku::DekuContainerRead;
+#[allow(unused_imports)]
+use log::{debug, info, trace, warn};
+
+use mctp::{AsyncListener, AsyncRespChannel};
 use mctp_linux::MctpLinuxAsyncListener;
-use pldm::PldmRequest;
+use pldm::{PldmRequest, PldmResponse};
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
+use std::os::unix::fs::MetadataExt;
 
 struct Host {
     file: RefCell<File>,
 }
 
 const FILENAME: &str = "pldm-file-host.bin";
+const PDR_HANDLE: u32 = 1;
 
 impl Host {
     fn new() -> Result<Self> {
         Ok(Self {
-            file: RefCell::new(
-                File::open(FILENAME).context("cannot open input file")?,
-            ),
+            file: RefCell::new(File::open(FILENAME).with_context(|| {
+                format!("cannot open input file {FILENAME}")
+            })?),
         })
     }
 }
@@ -34,6 +39,8 @@ impl pldm_file::host::Host for Host {
 type FileResponder = pldm_file::host::Responder<1>;
 
 fn main() -> Result<()> {
+    env_logger::init();
+
     let mut listener = MctpLinuxAsyncListener::new(mctp::MCTP_TYPE_PLDM, None)?;
     let mut pldm_ctrl = pldm::control::responder::Responder::<2>::new();
     let mut pldm_file = FileResponder::new();
@@ -72,10 +79,130 @@ fn main() -> Result<()> {
                     .request_in(chan, &req, &mut host)
                     .await
                     .context("PLDM file handler failed")?,
+                (pldm_platform::PLDM_TYPE_PLATFORM, _) => {
+                    handle_platform(chan, &req, &host)
+                        .await
+                        .context("PLDM platform handler failed")?
+                }
                 (t, _) => {
                     Err(anyhow::anyhow!("unexpected PLDM type {t}"))?;
                 }
             }
         }
     })
+}
+
+async fn handle_platform<R: AsyncRespChannel>(
+    mut comm: R,
+    req: &PldmRequest<'_>,
+    host: &Host,
+) -> Result<()> {
+    use pldm_platform::deku::DekuContainerWrite;
+    use pldm_platform::proto::*;
+
+    assert_eq!(req.typ, pldm_platform::PLDM_TYPE_PLATFORM);
+
+    let mut resp = req.response();
+
+    resp.cc = match Cmd::try_from(req.cmd)? {
+        Cmd::GetPDRRepositoryInfo => {
+            let pdrinfo = GetPDRRepositoryInfoResp {
+                state: PDRRepositoryState::Available,
+                update_time: [0u8; 13],
+                oem_update_time: [0u8; 13],
+                record_count: 1,
+                // TODO. "An implementation is allowed to round this number up to the nearest kilobyte (1024 bytes)."
+                repository_size: 1024,
+                // TODO
+                largest_record_size: 128,
+                // No Timeout
+                data_transfer_handle_timeout: 0x00,
+            };
+            resp.set_data(pdrinfo.to_bytes().context("Encoding failed")?);
+            Ok(pldm::CCode::SUCCESS as u8)
+        }
+        Cmd::GetPDR => handle_get_pdr(req, &mut resp, host),
+        other => {
+            warn!("Unsupported PLDM platform command {other:?}");
+            Ok(pldm::CCode::ERROR_UNSUPPORTED_PLDM_CMD as u8)
+        }
+    }?;
+
+    pldm::pldm_tx_resp_async(&mut comm, &resp)
+        .await
+        .context("Sending response failed")
+}
+
+fn handle_get_pdr(
+    req: &PldmRequest<'_>,
+    resp: &mut PldmResponse,
+    host: &Host,
+) -> Result<u8> {
+    use pldm_platform::deku::DekuContainerWrite;
+    use pldm_platform::proto::*;
+
+    let ((rest, _), pdr_req) = GetPDRReq::from_bytes((&req.data, 0))?;
+    if !rest.is_empty() {
+        bail!("Extra Get PDR Request bytes");
+    }
+
+    if pdr_req.record_handle != PDR_HANDLE {
+        warn!("Wrong PDR handle");
+        return Ok(plat_codes::INVALID_RECORD_HANDLE);
+    }
+    if pdr_req.data_transfer_handle != 0 {
+        warn!("Don't support multipart PDR");
+        return Ok(plat_codes::INVALID_DATA_TRANSFER_HANDLE);
+    }
+    if pdr_req.transfer_operation_flag != TransferOperationFlag::FirstPart {
+        warn!("Don't support multipart PDR");
+        return Ok(plat_codes::INVALID_TRANSFER_OPERATION_FLAG);
+    }
+    if pdr_req.record_change_number != 0 {
+        warn!("Don't support multipart PDR");
+        return Ok(plat_codes::INVALID_RECORD_CHANGE_NUMBER);
+    }
+
+    let file_max_size = host
+        .file
+        .borrow()
+        .metadata()
+        .context("Metadata failed")?
+        .size()
+        .try_into()
+        .context("File size > u32")?;
+
+    // null terminated filename
+    let mut file_name = FILENAME.as_bytes().to_vec();
+    file_name.push(0x00);
+    let file_name = pldm_platform::Vec::from_slice(&file_name).unwrap();
+
+    let pdr_resp = GetPDRResp::new_single(
+        pdr_req.record_handle,
+        PdrRecord::FileDescriptor(FileDescriptorPdr {
+            terminus_handle: 0,
+            file_identifier: 0,
+            // Management Controller Firmware
+            // TODO
+            entity_type: entity_type::LOGICAL | 36,
+            entity_instance: 0,
+            container_id: 0,
+            superior_directory: 0,
+            file_classification: FileClassification::OtherFile,
+            oem_file_classification: 0,
+            capabilities: file_capabilities::EX_READ_OPEN,
+            file_version: 0xFFFFFFFF,
+            file_max_size,
+            // TODO
+            file_max_desc_count: 1,
+            file_name_length: file_name.len() as u8,
+            file_name: file_name.into(),
+            oem_file_name: Default::default(),
+        }),
+    )?;
+    let enc = pdr_resp.to_bytes().context("Encoding failed")?;
+    trace!("enc {enc:02x?}");
+    resp.set_data(enc);
+
+    Ok(pldm::CCode::SUCCESS as u8)
 }

--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
                 // we pass all of the multipart receive commands over to
                 // the pldm-file handler
                 (pldm::control::PLDM_TYPE_CONTROL, MP_RECV) => pldm_file
-                    .multipart_request_in(chan, &req, &mut host)
+                    .multipart_request_in(chan, &req, &pldm_ctrl, &mut host)
                     .await
                     .context("PLDM file multipart handler failed")?,
                 (pldm::control::PLDM_TYPE_CONTROL, _) => pldm_ctrl

--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -1,0 +1,81 @@
+use anyhow::{Context, Result};
+use log::warn;
+use mctp::AsyncListener;
+use mctp_linux::MctpLinuxAsyncListener;
+use pldm::PldmRequest;
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+
+struct Host {
+    file: RefCell<File>,
+}
+
+const FILENAME: &str = "pldm-file-host.bin";
+
+impl Host {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            file: RefCell::new(
+                File::open(FILENAME).context("cannot open input file")?,
+            ),
+        })
+    }
+}
+
+impl pldm_file::host::Host for Host {
+    fn read(&self, buf: &mut [u8], offset: usize) -> std::io::Result<usize> {
+        let mut file = self.file.borrow_mut();
+        file.seek(SeekFrom::Start(offset as u64))?;
+        file.read(buf)
+    }
+}
+
+type FileResponder = pldm_file::host::Responder<1>;
+
+fn main() -> Result<()> {
+    let mut listener = MctpLinuxAsyncListener::new(mctp::MCTP_TYPE_PLDM, None)?;
+    let mut pldm_ctrl = pldm::control::responder::Responder::<2>::new();
+    let mut pldm_file = FileResponder::new();
+    let mut host = Host::new().context("unable to create file host")?;
+
+    FileResponder::register(&mut pldm_ctrl)?;
+
+    let mut buf = [0u8; 4096];
+
+    smol::block_on(async {
+        loop {
+            let (typ, _ic, buf, chan) = listener.recv(&mut buf).await?;
+
+            if typ != mctp::MCTP_TYPE_PLDM {
+                warn!("unexpected MCTP type {typ}");
+                continue;
+            }
+
+            let req = PldmRequest::from_buf_borrowed(buf)
+                .context("invalid PLDM message")?;
+
+            const MP_RECV: u8 = pldm::control::Cmd::MultipartReceive as u8;
+
+            match (req.typ, req.cmd) {
+                // we pass all of the multipart receive commands over to
+                // the pldm-file handler
+                (pldm::control::PLDM_TYPE_CONTROL, MP_RECV) => pldm_file
+                    .multipart_request_in(chan, &req, &mut host)
+                    .await
+                    .context("PLDM file multipart handler failed")?,
+                (pldm::control::PLDM_TYPE_CONTROL, _) => pldm_ctrl
+                    .handle_async(&req, chan)
+                    .await
+                    .context("PLDM control handler failed")?,
+                (pldm_file::PLDM_TYPE_FILE_TRANSFER, _) => pldm_file
+                    .request_in(chan, &req, &mut host)
+                    .await
+                    .context("PLDM file handler failed")?,
+                (t, _) => {
+                    Err(anyhow::anyhow!("unexpected PLDM type {t}"))?;
+                }
+            }
+        }
+    })
+}

--- a/pldm-file/src/client.rs
+++ b/pldm-file/src/client.rs
@@ -1,5 +1,6 @@
 use deku::{DekuContainerRead, DekuContainerWrite};
 use log::trace;
+use pldm::control::{MultipartReceiveReq, MultipartReceiveResp};
 use pldm::{pldm_xfer_buf_async, proto_error, PldmError, PldmRequest, Result};
 
 use crate::proto::*;
@@ -37,4 +38,123 @@ pub async fn df_properties(
     }
 
     Ok(ret.value)
+}
+
+pub async fn df_open(
+    comm: &mut impl mctp::AsyncReqChannel,
+    id: FileIdentifier,
+    attributes: DfOpenAttributes,
+) -> Result<FileDescriptor> {
+    let req = DfOpenReq {
+        file_identifier: id.0,
+        attributes: attributes.as_u16(),
+    };
+
+    let mut buf = [0; 10];
+    let l = req.to_slice(&mut buf).map_err(|_| PldmError::NoSpace)?;
+    let buf = &buf[..l];
+
+    let req = PldmRequest::new_borrowed(
+        PLDM_TYPE_FILE_TRANSFER,
+        Cmd::DfOpen as u8,
+        buf,
+    );
+
+    let mut rx = [0; 10];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx).await?;
+
+    let ((rest, _), ret) =
+        DfOpenResp::from_bytes((&resp.data, 0)).map_err(|e| {
+            trace!("DfOpen parse error {e}");
+            proto_error!("Bad DfOpen response")
+        })?;
+
+    if !rest.is_empty() {
+        return Err(proto_error!("Extra response"));
+    }
+
+    Ok(FileDescriptor(ret.file_descriptor))
+}
+
+const PART_SIZE: usize = 1024;
+
+pub async fn df_read(
+    comm: &mut impl mctp::AsyncReqChannel,
+    file: FileDescriptor,
+    offset: usize,
+    buf: &mut [u8],
+) -> Result<usize> {
+    if offset > u32::MAX as usize {
+        return Err(proto_error!("invalid offset"));
+    }
+    if buf.len() > u32::MAX as usize {
+        return Err(proto_error!("invalid length"));
+    }
+
+    let mut part_offset = 0;
+    let mut req = MultipartReceiveReq {
+        pldm_type: PLDM_TYPE_FILE_TRANSFER,
+        xfer_op: pldm::control::xfer_op::FIRST_PART,
+        xfer_context: file.0 as u32,
+        xfer_handle: 0,
+        req_offset: offset as u32,
+        req_length: buf.len() as u32,
+    };
+    loop {
+        let mut tx_buf = [0; 18];
+        let l = req.to_slice(&mut tx_buf).map_err(|_| PldmError::NoSpace)?;
+        let tx_buf = &tx_buf[..l];
+
+        let pldm_req = PldmRequest::new_borrowed(
+            pldm::control::PLDM_TYPE_CONTROL,
+            pldm::control::Cmd::MultipartReceive as u8,
+            tx_buf,
+        );
+
+        // todo: negotiated length
+        let mut rx_buf = [0u8; 14 + PART_SIZE + 4];
+        let resp = pldm_xfer_buf_async(comm, pldm_req, &mut rx_buf).await?;
+
+        let ((rest, _), read_resp) =
+            MultipartReceiveResp::from_bytes((&resp.data, 0)).map_err(|e| {
+                trace!("DfRead parse error {e}");
+                proto_error!("Bad DfOpen response")
+            })?;
+
+        let resp_data_len = read_resp.len as usize;
+
+        if rest.len() != resp_data_len + 4 {
+            return Err(proto_error!("invalid resonse data length"));
+        }
+
+        let (resp_data, resp_cs) = rest.split_at(resp_data_len);
+
+        let crc32 = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
+        let calc_cs = crc32.checksum(resp_data);
+        // unwrap: we have asserted the lengths above
+        let cs = u32::from_le_bytes(resp_cs.try_into().unwrap());
+
+        if calc_cs != cs {
+            return Err(proto_error!("data checksum mismatch"));
+        }
+
+        let total_len = part_offset + resp_data_len;
+
+        if total_len > buf.len() {
+            return Err(proto_error!("host data data overflow?"));
+        }
+
+        buf[part_offset..total_len].copy_from_slice(resp_data);
+
+        if read_resp.xfer_flag & pldm::control::xfer_flag::END != 0 {
+            break Ok(total_len);
+        }
+
+        part_offset = total_len;
+        req.xfer_op = pldm::control::xfer_op::NEXT_PART;
+        req.xfer_context = 0;
+        req.xfer_handle = read_resp.next_handle;
+        req.req_offset = 0;
+        req.req_length = 0;
+    }
 }

--- a/pldm-file/src/client.rs
+++ b/pldm-file/src/client.rs
@@ -1,0 +1,40 @@
+use deku::{DekuContainerRead, DekuContainerWrite};
+use log::trace;
+use pldm::{pldm_xfer_buf_async, proto_error, PldmError, PldmRequest, Result};
+
+use crate::proto::*;
+use crate::PLDM_TYPE_FILE_TRANSFER;
+
+pub async fn df_properties(
+    comm: &mut impl mctp::AsyncReqChannel,
+    property: DfProperty,
+) -> Result<u32> {
+    let req = DfPropertiesReq {
+        property: property as u32,
+    };
+
+    let mut buf = [0; 10];
+    let l = req.to_slice(&mut buf).map_err(|_| PldmError::NoSpace)?;
+    let buf = &buf[..l];
+
+    let req = PldmRequest::new_borrowed(
+        PLDM_TYPE_FILE_TRANSFER,
+        Cmd::DfProperties as u8,
+        buf,
+    );
+
+    let mut rx = [0; 30];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx).await?;
+
+    let ((rest, _), ret) = DfPropertiesResp::from_bytes((&resp.data, 0))
+        .map_err(|e| {
+            trace!("DfProperties parse error {e}");
+            proto_error!("Bad DfProperties response")
+        })?;
+
+    if !rest.is_empty() {
+        return Err(proto_error!("Extra response"));
+    }
+
+    Ok(ret.value)
+}

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -93,7 +93,12 @@ impl<const N: usize> Responder<N> {
             PLDM_TYPE_FILE_TRANSFER,
             0xf1f0f000,
             Some(MAX_PART_SIZE),
-            &[Cmd::DfProperties as u8],
+            &[
+                Cmd::DfProperties as u8,
+                Cmd::DfOpen as u8,
+                Cmd::DfClose as u8,
+                Cmd::DfRead as u8,
+            ],
         )
     }
 

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -142,8 +142,8 @@ impl<const N: usize> Responder<N> {
 
         if let Err((typ, e)) = res {
             debug!("error sending {typ} response. {e:?}");
+            return Err(e);
         }
-
         Ok(())
     }
 

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -13,8 +13,6 @@ use crate::proto::file_ccode;
 use crate::proto::*;
 use crate::PLDM_TYPE_FILE_TRANSFER;
 
-pub struct FileIdentifier(pub u16);
-
 const FILE_ID: FileIdentifier = FileIdentifier(0);
 
 // todo: negotiate this
@@ -25,8 +23,6 @@ pub trait Host {
     // just a single-file implementation
     fn read(&self, buf: &mut [u8], offset: usize) -> std::io::Result<usize>;
 }
-
-struct FileDescriptor(u16);
 
 // Created at the first stage (XFER_FIRST_PART) of a MultpartReceive,
 // where we have the offset and size.

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use deku::{DekuContainerRead, DekuContainerWrite, DekuError};
+use log::{debug, trace};
+use mctp::AsyncRespChannel;
+use num_traits::FromPrimitive;
+use pldm::{
+    self, pldm_tx_resp_async, proto_error, CCode, PldmError, PldmRequest,
+    PldmResponse,
+};
+
+use crate::proto::file_ccode;
+use crate::proto::*;
+use crate::PLDM_TYPE_FILE_TRANSFER;
+
+pub struct FileIdentifier(pub u16);
+
+const FILE_ID: FileIdentifier = FileIdentifier(0);
+
+// todo: negotiate this
+const PART_SIZE: usize = 1024;
+
+pub trait Host {
+    /// Returns number of bytes read
+    // just a single-file implementation
+    fn read(&self, buf: &mut [u8], offset: usize) -> std::io::Result<usize>;
+}
+
+struct FileDescriptor(u16);
+
+// Created at the first stage (XFER_FIRST_PART) of a MultpartReceive,
+// where we have the offset and size.
+struct FileTransferContext {
+    buf: Vec<u8>,
+    offset: usize,
+}
+
+// Created on DfOpen
+struct FileContext {
+    xfer_ctx: Option<FileTransferContext>,
+}
+
+pub struct Responder<const N: usize> {
+    files: [Option<FileContext>; N],
+}
+
+#[derive(Debug)]
+struct PldmFileError(u8);
+
+impl From<CCode> for PldmFileError {
+    fn from(cc: CCode) -> Self {
+        Self(cc as u8)
+    }
+}
+
+impl From<u8> for PldmFileError {
+    fn from(cc: u8) -> Self {
+        Self(cc)
+    }
+}
+
+impl From<DekuError> for PldmFileError {
+    fn from(_: DekuError) -> Self {
+        CCode::ERROR_INVALID_DATA.into()
+    }
+}
+
+impl From<PldmError> for PldmFileError {
+    fn from(_: PldmError) -> Self {
+        CCode::ERROR.into()
+    }
+}
+
+impl From<PldmFileError> for u8 {
+    fn from(err: PldmFileError) -> Self {
+        err.0
+    }
+}
+impl std::fmt::Display for PldmFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CC: {}", self.0)
+    }
+}
+
+type Result<T> = std::result::Result<T, PldmFileError>;
+
+impl<const N: usize> Responder<N> {
+    pub fn new() -> Self {
+        Self {
+            files: [const { None }; N],
+        }
+    }
+
+    pub fn register<const T: usize>(
+        pldm: &mut pldm::control::responder::Responder<T>,
+    ) -> pldm::Result<()> {
+        pldm.register_type(
+            PLDM_TYPE_FILE_TRANSFER,
+            0xf1f0f000,
+            Some(PART_SIZE as u16),
+            &[Cmd::DfProperties as u8],
+        )
+    }
+
+    pub async fn request_in<R: AsyncRespChannel>(
+        &mut self,
+        mut comm: R,
+        req: &PldmRequest<'_>,
+        host: &mut impl Host,
+    ) -> pldm::Result<()> {
+        if req.typ != PLDM_TYPE_FILE_TRANSFER {
+            trace!("pldm-fw non-pldm-fw request {req:?}");
+            return Err(proto_error!("Unexpected pldm-fw request"));
+        }
+
+        let Some(cmd) = Cmd::from_u8(req.cmd) else {
+            let _ = self
+                .reply_error(
+                    req,
+                    &mut comm,
+                    CCode::ERROR_UNSUPPORTED_PLDM_CMD as u8,
+                )
+                .await;
+            return Ok(());
+        };
+
+        let r = match cmd {
+            Cmd::DfProperties => self.cmd_dfproperties(req, host),
+            Cmd::DfOpen => self.cmd_dfopen(req, host),
+            _ => {
+                trace!("unhandled command {cmd:?}");
+                Err(CCode::ERROR_UNSUPPORTED_PLDM_CMD.into())
+            }
+        };
+
+        let res = match r {
+            Ok(resp) => pldm_tx_resp_async(&mut comm, &resp)
+                .await
+                .map_err(|e| ("command", e)),
+            Err(e) => {
+                debug!("Error handling {cmd:?}: {e:?}");
+                self.reply_error(req, &mut comm, e.into())
+                    .await
+                    .map_err(|e| ("failure", e))
+            }
+        };
+
+        if let Err((typ, e)) = res {
+            debug!("error sending {typ} response. {e:?}");
+        }
+
+        Ok(())
+    }
+
+    // We may want to move this to the general request_in() path?
+    pub async fn multipart_request_in<R: AsyncRespChannel>(
+        &mut self,
+        mut comm: R,
+        req: &PldmRequest<'_>,
+        host: &mut impl Host,
+    ) -> pldm::Result<()> {
+        let Ok(cmd) = pldm::control::Cmd::try_from(req.cmd) else {
+            return self
+                .reply_error(
+                    req,
+                    &mut comm,
+                    CCode::ERROR_UNSUPPORTED_PLDM_CMD as u8,
+                )
+                .await;
+        };
+
+        let res = match cmd {
+            pldm::control::Cmd::MultipartReceive => {
+                self.cmd_multipart_receive(req, host)
+            }
+            _ => {
+                trace!("unhandled multipart request");
+                Err(CCode::ERROR_UNSUPPORTED_PLDM_CMD.into())
+            }
+        };
+
+        match res {
+            Ok(resp) => pldm_tx_resp_async(&mut comm, &resp).await,
+            Err(e) => {
+                debug!("Error handling multipart command: {e:?}");
+                self.reply_error(req, &mut comm, e.into()).await
+            }
+        }
+    }
+
+    async fn reply_error<R: AsyncRespChannel>(
+        &self,
+        req: &PldmRequest<'_>,
+        comm: &mut R,
+        cc: u8,
+    ) -> std::result::Result<(), PldmError> {
+        let mut resp = req.response();
+        resp.cc = cc;
+        pldm_tx_resp_async(comm, &resp).await
+    }
+
+    fn cmd_dfproperties<'a>(
+        &mut self,
+        req: &'a PldmRequest<'a>,
+        _host: &mut impl Host,
+    ) -> Result<PldmResponse<'a>> {
+        let (rest, dfp) = DfPropertiesReq::from_bytes((&req.data, 0))?;
+
+        if !rest.0.is_empty() {
+            Err(CCode::ERROR_INVALID_DATA)?;
+        }
+
+        let prop = DfProperty::try_from(dfp.property)
+            .map_err(|_| file_ccode::INVALID_DF_ATTRIBUTE)?;
+
+        // fixed properties at present...
+        let value = match prop {
+            DfProperty::MaxConcurrentMedium => 1u32,
+            DfProperty::MaxFileDescriptors => 1u32,
+        };
+
+        let prop_resp = DfPropertiesResp { value };
+        let mut resp = req.response();
+        resp.set_data(prop_resp.to_bytes()?);
+
+        Ok(resp)
+    }
+
+    fn cmd_dfopen<'a>(
+        &mut self,
+        req: &'a PldmRequest<'a>,
+        _host: &mut impl Host,
+    ) -> Result<PldmResponse<'a>> {
+        let (rest, dfo) = DfOpenReq::from_bytes((&req.data, 0))?;
+
+        if !rest.0.is_empty() {
+            Err(CCode::ERROR_INVALID_LENGTH)?;
+        }
+
+        if dfo.file_identifier != FILE_ID.0 {
+            Err(file_ccode::INVALID_FILE_IDENTIFIER)?;
+        }
+
+        // todo: attributes
+
+        // single file implementation, requires no file-specific context
+        let file_ctx = FileContext { xfer_ctx: None };
+
+        let id = self
+            .files
+            .iter()
+            .enumerate()
+            .find_map(|(n, e)| if e.is_none() { Some(n) } else { None })
+            .ok_or(file_ccode::MAX_NUM_FDS_EXCEEDED)?;
+
+        self.files[id].replace(file_ctx);
+
+        let dfo_resp = DfOpenResp {
+            file_descriptor: id as u16,
+        };
+
+        let mut resp = req.response();
+        resp.set_data(dfo_resp.to_bytes()?);
+
+        Ok(resp)
+    }
+
+    fn cmd_multipart_receive<'a>(
+        &mut self,
+        req: &'a PldmRequest<'a>,
+        host: &mut impl Host,
+    ) -> Result<PldmResponse<'a>> {
+        let (rest, cmd) = pldm::control::MultipartReceiveReq::from_bytes((
+            req.data.as_ref(),
+            0,
+        ))?;
+
+        if !rest.0.is_empty() {
+            Err(CCode::ERROR_INVALID_LENGTH)?;
+        }
+
+        // MultipartRead context is 32bits, but file descriptors are 16...
+        if cmd.xfer_context > u16::MAX as u32 {
+            Err(CCode::ERROR_INVALID_TRANSFER_CONTEXT)?;
+        }
+
+        let fd = FileDescriptor(cmd.xfer_context as u16);
+
+        let file_ctx = self
+            .files
+            .get_mut(fd.0 as usize)
+            .ok_or(CCode::ERROR_INVALID_TRANSFER_CONTEXT)? // valid?
+            .as_mut()
+            .ok_or(CCode::ERROR_INVALID_TRANSFER_CONTEXT)?; // open?
+
+        // handle termination
+        if cmd.xfer_op == pldm::control::xfer_op::ABORT
+            || cmd.xfer_op == pldm::control::xfer_op::COMPLETE
+        {
+            file_ctx.xfer_ctx.take();
+            let dfread_resp = pldm::control::MultipartReceiveResp {
+                xfer_flag: pldm::control::xfer_flag::ACKNOWLEDGE_COMPLETION,
+                next_handle: 0,
+                len: 0,
+            };
+            let mut resp = req.response();
+            resp.set_data(dfread_resp.to_bytes()?);
+            return Ok(resp);
+        }
+
+        // Set new transfer context
+        if cmd.xfer_op == pldm::control::xfer_op::FIRST_PART {
+            if let Some(ctx) = file_ctx.xfer_ctx.as_mut() {
+                ctx.offset = 0;
+            } else {
+                let new_ctx = Self::init_read(&cmd, host)?;
+                // a repeated FIRST_PART is valid, and restarts the transfer
+                file_ctx.xfer_ctx.replace(new_ctx);
+            };
+        }
+
+        let xfer_ctx = file_ctx.xfer_ctx.as_mut().ok_or(CCode::ERROR)?;
+        let full_len = xfer_ctx.buf.len();
+
+        let offset = match cmd.xfer_op {
+            pldm::control::xfer_op::FIRST_PART
+            | pldm::control::xfer_op::CURRENT_PART => xfer_ctx.offset,
+            pldm::control::xfer_op::NEXT_PART => xfer_ctx.offset + PART_SIZE,
+            _ => Err(CCode::ERROR_INVALID_DATA)?,
+        };
+
+        if offset >= xfer_ctx.buf.len() {
+            Err(CCode::ERROR_INVALID_DATA)?;
+        }
+
+        let start = offset == 0;
+        let (len, end) = if offset + PART_SIZE >= full_len {
+            (full_len - offset, true)
+        } else {
+            (PART_SIZE, false)
+        };
+
+        let mut flags = 0;
+        if start {
+            flags |= pldm::control::xfer_flag::START
+        }
+        if end {
+            flags |= pldm::control::xfer_flag::END
+        }
+        // spec defines useless flags :(
+        if flags == 0 {
+            flags |= pldm::control::xfer_flag::MIDDLE
+        }
+
+        let mut resp = req.response();
+        let dfread_resp = pldm::control::MultipartReceiveResp {
+            xfer_flag: flags,
+            next_handle: 0,
+            len: len as u32,
+        };
+
+        let mut resp_data = Vec::new();
+        resp_data.extend_from_slice(&dfread_resp.to_bytes()?);
+
+        let data = &xfer_ctx.buf[offset..offset + len];
+        let crc32 = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
+        let cs = crc32.checksum(data);
+
+        resp_data.extend_from_slice(data);
+        resp_data.extend_from_slice(&cs.to_le_bytes());
+
+        xfer_ctx.offset = offset;
+        resp.set_data(resp_data);
+
+        Ok(resp)
+    }
+
+    fn init_read(
+        req: &pldm::control::MultipartReceiveReq,
+        host: &mut impl Host,
+    ) -> Result<FileTransferContext> {
+        let offset = req.req_offset;
+        let len = req.req_length;
+
+        let mut buf = vec![0; len as usize];
+        let read_len =
+            host.read(&mut buf, offset as usize).or(Err(CCode::ERROR))?;
+
+        buf.truncate(read_len);
+
+        Ok(FileTransferContext { buf, offset: 0 })
+    }
+}
+
+impl<const N: usize> Default for Responder<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/pldm-file/src/lib.rs
+++ b/pldm-file/src/lib.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+pub const PLDM_TYPE_FILE_TRANSFER: u8 = 7;
+
+pub mod client;
+#[cfg(feature = "std")]
+pub mod host;
+pub mod proto;

--- a/pldm-file/src/proto.rs
+++ b/pldm-file/src/proto.rs
@@ -36,10 +36,10 @@ pub mod file_ccode {
     pub const UNABLE_TO_OPEN_FILE: u8 = 0x8a;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct FileIdentifier(pub u16);
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct FileDescriptor(pub u16);
 
 // These are represented as their encoding in the DfProperties command;

--- a/pldm-file/src/proto.rs
+++ b/pldm-file/src/proto.rs
@@ -1,6 +1,7 @@
 use num_derive::FromPrimitive;
 
 use deku::{DekuRead, DekuWrite};
+use enumset::{EnumSet, EnumSetType};
 
 /// PLDM for File Transfer commands
 #[allow(missing_docs)]
@@ -48,6 +49,16 @@ pub enum DfProperty {
     MaxConcurrentMedium = 0x01,
     MaxFileDescriptors = 0x02,
 }
+
+#[derive(EnumSetType, Debug)]
+pub enum DfOpenAttribute {
+    DfOpenWrite = 0,
+    DfOpenExclusive = 1,
+    DfOpenFifo = 2,
+    DfOpenPushed = 3,
+}
+
+pub type DfOpenAttributes = EnumSet<DfOpenAttribute>;
 
 impl TryFrom<u32> for DfProperty {
     type Error = ();

--- a/pldm-file/src/proto.rs
+++ b/pldm-file/src/proto.rs
@@ -60,6 +60,13 @@ pub enum DfOpenAttribute {
 
 pub type DfOpenAttributes = EnumSet<DfOpenAttribute>;
 
+#[derive(EnumSetType, Debug)]
+pub enum DfCloseAttribute {
+    DfCloseZeroLength = 0,
+}
+
+pub type DfCloseAttributes = EnumSet<DfCloseAttribute>;
+
 impl TryFrom<u32> for DfProperty {
     type Error = ();
 
@@ -91,4 +98,10 @@ pub struct DfOpenReq {
 #[derive(DekuRead, DekuWrite)]
 pub struct DfOpenResp {
     pub file_descriptor: u16,
+}
+
+#[derive(DekuRead, DekuWrite)]
+pub struct DfCloseReq {
+    pub file_descriptor: u16,
+    pub attributes: u16,
 }

--- a/pldm-file/src/proto.rs
+++ b/pldm-file/src/proto.rs
@@ -1,0 +1,77 @@
+use num_derive::FromPrimitive;
+
+use deku::{DekuRead, DekuWrite};
+
+/// PLDM for File Transfer commands
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, FromPrimitive)]
+#[repr(u8)]
+pub enum Cmd {
+    DfOpen = 0x01,
+    DfClose = 0x02,
+    DfHeartbeat = 0x03,
+    DfProperties = 0x10,
+    DfGetFileAttribute = 0x11,
+    DfSetFileAttribute = 0x12,
+    // the following two are implemented as type-0 multipart commands, but
+    // we need command identifiers for GetPLDMCommands.
+    DfRead = 0x20,
+    DfFifoSend = 0x21,
+}
+
+#[allow(missing_docs)]
+pub mod file_ccode {
+    pub const INVALID_FILE_DESCRIPTOR: u8 = 0x80;
+    pub const INVALID_DF_ATTRIBUTE: u8 = 0x81;
+    pub const ZEROLENGTH_NOT_ALLOWED: u8 = 0x82;
+    pub const EXCLUSIVE_OWNERSHIP_NOT_ESTABLISHED: u8 = 0x83;
+    pub const EXCLUSIVE_OWNERSHIP_NOT_ALLOWED: u8 = 0x84;
+    pub const EXCLUSIVE_OWNERSHIP_NOT_AVAILABLE: u8 = 0x85;
+    pub const INVALID_FILE_IDENTIFIER: u8 = 0x86;
+    pub const DFOPEN_DIR_NOT_ALLOWED: u8 = 0x87;
+    pub const MAX_NUM_FDS_EXCEEDED: u8 = 0x88;
+    pub const FILE_OPEN: u8 = 0x89;
+    pub const UNABLE_TO_OPEN_FILE: u8 = 0x8a;
+}
+
+// These are represented as their encoding in the DfProperties command;
+// a bitmask, where only one value is permitted.
+#[repr(u32)]
+pub enum DfProperty {
+    MaxConcurrentMedium = 0x01,
+    MaxFileDescriptors = 0x02,
+}
+
+impl TryFrom<u32> for DfProperty {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(Self::MaxConcurrentMedium),
+            0x02 => Ok(Self::MaxFileDescriptors),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(DekuRead, DekuWrite)]
+pub struct DfPropertiesReq {
+    pub property: u32,
+}
+
+#[derive(DekuRead, DekuWrite)]
+pub struct DfPropertiesResp {
+    pub value: u32,
+}
+
+#[derive(DekuRead, DekuWrite)]
+pub struct DfOpenReq {
+    pub file_identifier: u16,
+    pub attributes: u16,
+}
+
+#[derive(DekuRead, DekuWrite)]
+pub struct DfOpenResp {
+    pub file_descriptor: u16,
+}

--- a/pldm-file/src/proto.rs
+++ b/pldm-file/src/proto.rs
@@ -35,6 +35,12 @@ pub mod file_ccode {
     pub const UNABLE_TO_OPEN_FILE: u8 = 0x8a;
 }
 
+#[derive(Debug)]
+pub struct FileIdentifier(pub u16);
+
+#[derive(Debug)]
+pub struct FileDescriptor(pub u16);
+
 // These are represented as their encoding in the DfProperties command;
 // a bitmask, where only one value is permitted.
 #[repr(u32)]

--- a/pldm-fw/src/lib.rs
+++ b/pldm-fw/src/lib.rs
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2023 Code Construct
  */
-#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 // #![warn(missing_docs)]
 
@@ -30,7 +30,8 @@ use nom::{
 #[cfg(feature = "alloc")]
 use nom::multi::{count, length_count};
 
-extern crate pldm;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 /// Firmware Device specific
 pub mod fd;

--- a/pldm-platform-util/Cargo.toml
+++ b/pldm-platform-util/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pldm-platform-util"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+argh = { workspace = true }
+deku = { workspace = true }
+env_logger =  { workspace = true }
+log = { workspace = true }
+mctp = { workspace = true }
+mctp-linux = { workspace = true }
+pldm-platform = { workspace = true, features = ["std"] }
+smol = { workspace = true }
+
+[features]
+deku-debug = ["deku/logging"]

--- a/pldm-platform-util/build.rs
+++ b/pldm-platform-util/build.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+fn main() {
+    let version = Command::new("git")
+        .args(["describe", "--always", "--dirty"])
+        .output()
+        .map(|o| String::from_utf8(o.stdout).unwrap().trim().to_string())
+        .unwrap_or("(unknown)".to_string());
+
+    let path_res = Command::new("git")
+        .args(["rev-parse", "--path-format=relative", "--git-dir"])
+        .output()
+        .map(|o| String::from_utf8(o.stdout).unwrap().trim().to_string());
+
+    println!("cargo:rustc-env=VERSION={version}");
+    if let Ok(path) = path_res {
+        println!("cargo:rerun-if-changed={path}/HEAD");
+        // default rerun paths get lost once any have been added.
+        println!("cargo:rerun-if-changed=.");
+    }
+}

--- a/pldm-platform-util/src/bin/pldm-platform.rs
+++ b/pldm-platform-util/src/bin/pldm-platform.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * PLDM platform utility.
+ *
+ * Copyright (c) 2025 Code Construct
+ */
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+use anyhow::{bail, Result};
+
+use argh::FromArgs;
+use mctp_linux::MctpAddr;
+
+use pldm_platform::proto::{SensorId, SetSensorOperationalState};
+
+#[derive(FromArgs, Debug)]
+#[argh(description = "PLDM platform requester")]
+struct Args {
+    #[argh(switch, short = 'd')]
+    /// debug logging
+    debug: bool,
+
+    #[argh(switch)]
+    /// trace logging
+    trace: bool,
+
+    /// MCTP net/EID of device
+    #[argh(positional)]
+    addr: MctpAddr,
+
+    #[argh(subcommand)]
+    command: Command,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand)]
+enum Command {
+    NumericSensor(NumericSensorCommand),
+    StateSensor(StateSensorCommand),
+    NumericEnable(NumericEnableCommand),
+    StateEnable(StateEnableCommand),
+    Version(VersionCommand),
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "version", description = "Print version")]
+struct VersionCommand {}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "numeric-sensor",
+    description = "Get Numeric Sensor Reading"
+)]
+struct NumericSensorCommand {
+    /// sensor ID
+    #[argh(positional)]
+    sensor: SensorId,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "state-sensor",
+    description = "Get State Sensor Reading. Only simple sensors supported."
+)]
+struct StateSensorCommand {
+    /// sensor ID
+    #[argh(positional)]
+    sensor: SensorId,
+
+    /// state set
+    #[argh(option)]
+    state_set: Option<u16>,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "numeric-enable",
+    description = "Set Numeric Sensor Enable"
+)]
+struct NumericEnableCommand {
+    /// event enable. disable, enable, op-only, state-only
+    #[argh(option)]
+    event: Option<String>,
+
+    /// sensor ID
+    #[argh(positional)]
+    sensor: SensorId,
+
+    /// operational state. enable, disable, unavailable
+    // TODO: could use enums once newer argh is released
+    #[argh(positional)]
+    op_state: String,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "state-enable",
+    description = "Set State Sensor Enable. Only simple sensors supported."
+)]
+struct StateEnableCommand {
+    /// event enable. disable, enable, op-only, state-only
+    #[argh(option)]
+    event: Option<String>,
+
+    /// sensor ID
+    #[argh(positional)]
+    sensor: SensorId,
+
+    /// operational state. enable, disable, unavailable
+    // TODO: could use enums once newer argh is released
+    #[argh(positional)]
+    op_state: String,
+}
+
+fn enable_command_op(op_state: &str) -> Result<SetSensorOperationalState> {
+    Ok(if op_state.starts_with("en") {
+        SetSensorOperationalState::Enabled
+    } else if op_state.starts_with("dis") {
+        SetSensorOperationalState::Disabled
+    } else if op_state.starts_with("un") {
+        SetSensorOperationalState::Unavailable
+    } else {
+        bail!("Bad operational state '{}'", op_state);
+    })
+}
+
+fn enable_command_op_event_enable(event: &Option<String>) -> Result<bool> {
+    Ok(if let Some(e) = event {
+        if e.starts_with("en") || e == "op-only" {
+            true
+        } else if e.starts_with("dis") || e == "state-only" {
+            false
+        } else {
+            bail!("Bad --event argument");
+        }
+    } else {
+        false
+    })
+}
+
+fn enable_command_state_event_enable(event: &Option<String>) -> Result<bool> {
+    Ok(if let Some(e) = event {
+        if e.starts_with("en") || e == "state-only" {
+            true
+        } else if e.starts_with("dis") || e == "op-only" {
+            false
+        } else {
+            bail!("Bad --event argument");
+        }
+    } else {
+        false
+    })
+}
+
+fn main() -> anyhow::Result<()> {
+    smol::block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
+    let args: Args = argh::from_env();
+
+    let level = if args.trace {
+        log::LevelFilter::Trace
+    } else if args.debug {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+
+    env_logger::Builder::new()
+        .filter_level(level)
+        .format_timestamp(None)
+        .init();
+
+    match args.command {
+        Command::Version(_) => info!("pldm-platform {}", env!("VERSION")),
+        Command::NumericSensor(s) => {
+            let mut ep = args.addr.create_req_async()?;
+            let reading = pldm_platform::requester::get_sensor_reading(
+                &mut ep, s.sensor, false,
+            )
+            .await?;
+            println!("Sensor {} {:?}", s.sensor.0, reading);
+        }
+        Command::StateSensor(s) => {
+            let mut ep = args.addr.create_req_async()?;
+            let reading =
+                pldm_platform::requester::get_simple_state_sensor_reading(
+                    &mut ep, s.sensor, false,
+                )
+                .await?;
+            if let Some(state_set) = s.state_set {
+                println!(
+                    "Sensor {} {:?}",
+                    s.sensor.0,
+                    reading.debug_state_set(state_set)
+                );
+            } else {
+                println!("Sensor {} {:?}", s.sensor.0, reading);
+            }
+        }
+        Command::NumericEnable(s) => {
+            let mut ep = args.addr.create_req_async()?;
+            pldm_platform::requester::set_numeric_sensor_enable(
+                &mut ep,
+                s.sensor,
+                enable_command_op(&s.op_state)?,
+                s.event.is_none(),
+                enable_command_op_event_enable(&s.event)?,
+                enable_command_state_event_enable(&s.event)?,
+            )
+            .await?;
+        }
+        Command::StateEnable(s) => {
+            let mut ep = args.addr.create_req_async()?;
+            pldm_platform::requester::set_simple_state_sensor_enables(
+                &mut ep,
+                s.sensor,
+                enable_command_op(&s.op_state)?,
+                s.event.is_none(),
+                enable_command_op_event_enable(&s.event)?,
+                enable_command_state_event_enable(&s.event)?,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}

--- a/pldm-platform/Cargo.toml
+++ b/pldm-platform/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pldm-platform"
+description = "Platform Level Data Model (PLDM) Platform Monitoring and Control"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+categories = ["network-programming", "embedded", "hardware-support"]
+
+[dependencies]
+deku = { workspace = true }
+heapless = { workspace = true }
+log = { workspace = true }
+mctp = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+pldm = { workspace = true }
+
+[features]
+default = ["std"]
+alloc = ["pldm/alloc", "deku/alloc"]
+std = ["alloc", "pldm/std", "mctp/std"]

--- a/pldm-platform/README.md
+++ b/pldm-platform/README.md
@@ -1,0 +1,15 @@
+# PLDM Platform
+
+This crate implements PLDM Platform ("type 2") handling.
+
+Currently only a subset of commands are implemented. 
+PLDM type 2 is defined by DMTF DSP0248 and DSP0249 (state sets).
+
+At the moment the crate requires `alloc`, that requirement will be relaxed later.
+
+[`pldm-platform-util`](../pldm-platform-util) crate provides a PLDM 
+requester program to run on Linux.
+
+
+
+

--- a/pldm-platform/src/lib.rs
+++ b/pldm-platform/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+pub mod proto;
+pub mod requester;
+pub mod state_sets;
+
+pub const PLDM_TYPE_PLATFORM: u8 = 2;
+
+/// Re-export of `heapless::Vec`
+pub use heapless::Vec;

--- a/pldm-platform/src/lib.rs
+++ b/pldm-platform/src/lib.rs
@@ -10,5 +10,9 @@ pub mod state_sets;
 
 pub const PLDM_TYPE_PLATFORM: u8 = 2;
 
+/// Re-export of `deku`.
+///
+/// Traits allow encoding/decoding [`pldm_platform::proto`](proto) data structures.
+pub use deku;
 /// Re-export of `heapless::Vec`
 pub use heapless::Vec;

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -1,0 +1,403 @@
+use core::{marker::PhantomData, num::ParseIntError, str::FromStr};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+use core::fmt::Debug;
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+
+use deku::{
+    ctx::Limit, deku_derive, writer::Writer, DekuEnumExt, DekuError, DekuRead,
+    DekuReader, DekuWrite, DekuWriter,
+};
+
+/// PLDM Platform Commands
+#[allow(missing_docs)]
+#[derive(FromPrimitive, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum Cmd {
+    GetTerminusUID = 0x03,
+    SetEventReceiver = 0x04,
+    GetEventReceiver = 0x05,
+    PlatformEventMessage = 0x0A,
+    PollForPlatformEventMessage = 0x0B,
+    EventMessageSupported = 0x0C,
+    EventMessageBufferSize = 0x0D,
+    SetNumericSensorEnable = 0x10,
+    GetSensorReading = 0x11,
+    GetSensorThresholds = 0x12,
+    SetSensorThresholds = 0x13,
+    RestoreSensorThresholds = 0x14,
+    GetSensorHysteresis = 0x15,
+    SetSensorHysteresis = 0x16,
+    InitNumericSensor = 0x17,
+    SetStateSensorEnables = 0x20,
+    GetStateSensorReadings = 0x21,
+    InitStateSensor = 0x22,
+    SetNumericEffecterEnable = 0x30,
+    SetNumericEffecterValue = 0x31,
+    GetNumericEffecterValue = 0x32,
+    SetStateEffecterEnables = 0x38,
+    SetStateEffecterStates = 0x39,
+    GetStateEffecterStates = 0x3A,
+    GetPLDMEventLogInfo = 0x40,
+    EnablePLDMEventLogging = 0x41,
+    ClearPLDMEventLog = 0x42,
+    GetPLDMEventLogTimestamp = 0x43,
+    SetPLDMEventLogTimestamp = 0x44,
+    ReadPLDMEventLog = 0x45,
+    GetPLDMEventLogPolicyInfo = 0x46,
+    SetPLDMEventLogPolicy = 0x47,
+    FindPLDMEventLogEntry = 0x48,
+    GetPDRRepositoryInfo = 0x50,
+    GetPDR = 0x51,
+    FindPDR = 0x52,
+    RunInitAgent = 0x58,
+    GetPDRRepositorySignature = 0x53,
+}
+
+// TODO: PlatformError type?
+
+/// PLDM platform response codes
+#[allow(missing_docs)]
+mod plat_codes {
+    pub const INVALID_SENSOR_ID: u8 = 0x80;
+    pub const EVENT_GENERATION_NOT_SUPPORTED: u8 = 0x82;
+}
+
+pub use plat_codes::*;
+
+// repr(u8) doesn't work with with field-less variants for Deku
+#[derive(Debug, Eq, PartialEq, Hash, Clone, DekuWrite, DekuRead)]
+#[deku(endian = "little", ctx = "data_size: u8", id = "data_size")]
+pub enum SensorData {
+    #[deku(id = 0)]
+    U8(u8),
+    #[deku(id = 1)]
+    I8(i8),
+    #[deku(id = 2)]
+    U16(u16),
+    #[deku(id = 3)]
+    I16(i16),
+    #[deku(id = 4)]
+    U32(u32),
+    #[deku(id = 5)]
+    I32(i32),
+    #[deku(id = 6)]
+    U64(u64),
+    #[deku(id = 7)]
+    I64(i64),
+}
+
+#[allow(missing_docs)]
+#[derive(
+    FromPrimitive, Debug, PartialEq, Eq, Copy, Clone, DekuRead, DekuWrite,
+)]
+#[deku(id_type = "u8")]
+#[repr(u8)]
+pub enum SensorOperationalState {
+    Enabled = 0,
+    Disabled,
+    Unavailable,
+    StatusUnknown,
+    Failed,
+    Initializing,
+    ShuttingDown,
+    InTest,
+}
+
+#[allow(missing_docs)]
+#[derive(
+    FromPrimitive, Debug, PartialEq, Eq, Copy, Clone, DekuRead, DekuWrite,
+)]
+#[deku(id_type = "u8")]
+#[repr(u8)]
+pub enum SetSensorOperationalState {
+    Enabled = 0,
+    Disabled,
+    Unavailable,
+}
+
+#[allow(missing_docs)]
+#[derive(
+    FromPrimitive, Debug, PartialEq, Eq, Copy, Clone, DekuRead, DekuWrite,
+)]
+#[deku(id_type = "u8")]
+#[repr(u8)]
+pub enum SensorEventMessageEnable {
+    /// NoEventGeneration for GetSensor, NoChange for SetSensorEnable
+    NoEventGeneration = 0,
+    EventsDisabled,
+    EventsEnabled,
+    OpEventsOnlyEnabled,
+    StateEventsOnlyEnabled,
+}
+
+impl SensorEventMessageEnable {
+    pub fn new(op_enable: bool, state_enable: bool) -> Self {
+        match (op_enable, state_enable) {
+            (true, true) => Self::EventsEnabled,
+            (false, false) => Self::EventsDisabled,
+            (true, false) => Self::OpEventsOnlyEnabled,
+            (false, true) => Self::StateEventsOnlyEnabled,
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(
+    FromPrimitive, Debug, PartialEq, Eq, Copy, Clone, DekuRead, DekuWrite,
+)]
+#[deku(id_type = "u8")]
+#[repr(u8)]
+pub enum SensorState {
+    Unknown = 0,
+    Normal,
+    Warning,
+    Critical,
+    Fatal,
+    LowerWarning,
+    LowerCritical,
+    LowerFatal,
+    UpperWarning,
+    UpperCritical,
+    UpperFatal,
+}
+
+#[derive(Debug, Clone)]
+pub struct VecWrap<T, const N: usize>(pub heapless::Vec<T, N>);
+
+impl<T, const N: usize> From<heapless::Vec<T, N>> for VecWrap<T, N> {
+    fn from(value: heapless::Vec<T, N>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T, const N: usize> core::ops::Deref for VecWrap<T, N> {
+    type Target = heapless::Vec<T, N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, const N: usize> core::ops::DerefMut for VecWrap<T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a, T, Predicate, Ctx, const N: usize>
+    DekuReader<'a, (Limit<T, Predicate>, Ctx)> for VecWrap<T, N>
+where
+    Predicate: FnMut(&T) -> bool,
+    Ctx: Copy,
+    T: DekuReader<'a, Ctx>,
+{
+    fn from_reader_with_ctx<
+        R: deku::no_std_io::Read + deku::no_std_io::Seek,
+    >(
+        reader: &mut deku::reader::Reader<R>,
+        (limit, ctx): (Limit<T, Predicate>, Ctx),
+    ) -> core::result::Result<Self, DekuError> {
+        let Limit::Count(count) = limit else {
+            return Err(DekuError::Assertion(
+                "Only count implemented for heapless::Vec".into(),
+            ));
+        };
+
+        let mut v = heapless::Vec::new();
+        for _ in 0..count {
+            v.push(T::from_reader_with_ctx(reader, ctx)?).map_err(|_| {
+                DekuError::InvalidParam("Too many elements".into())
+            })?
+        }
+
+        Ok(VecWrap(v))
+    }
+}
+
+impl<T, Ctx, const N: usize> DekuWriter<Ctx> for VecWrap<T, N>
+where
+    T: DekuWriter<Ctx>,
+    Ctx: Copy,
+{
+    // Required method
+    fn to_writer<W: deku::no_std_io::Write + deku::no_std_io::Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> core::result::Result<(), DekuError> {
+        self.0.to_writer(writer, ctx)
+    }
+}
+
+#[derive(Debug, DekuRead, DekuWrite, PartialEq, Eq, Clone, Copy)]
+#[deku(endian = "little")]
+pub struct SensorId(pub u16);
+
+impl FromStr for SensorId {
+    type Err = ParseIntError;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        Ok(Self(if let Some(s) = s.strip_prefix("0x") {
+            u16::from_str_radix(s, 16)
+        } else {
+            s.parse()
+        }?))
+    }
+}
+
+#[derive(Debug, DekuRead, DekuWrite, PartialEq, Eq, Clone)]
+pub struct GetSensorReadingReq {
+    pub sensor: SensorId,
+    pub rearm: bool,
+}
+
+#[deku_derive(DekuRead, DekuWrite)]
+#[derive(Debug, Clone)]
+pub struct GetSensorReadingResp {
+    #[deku(temp, temp_value = "reading.deku_id().unwrap()")]
+    data_size: u8,
+    pub op_state: SensorOperationalState,
+    pub event_enable: SensorEventMessageEnable,
+    pub present_state: SensorState,
+    pub previous_state: SensorState,
+    pub event_state: SensorState,
+    #[deku(ctx = "*data_size")]
+    pub reading: SensorData,
+}
+
+#[deku_derive(DekuRead, DekuWrite)]
+#[derive(Debug, Clone)]
+pub struct GetStateSensorReadingsReq {
+    pub sensor: SensorId,
+    pub rearm: u8,
+    #[deku(temp, temp_value = "0")]
+    rsvd: u8,
+}
+
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
+pub struct StateField {
+    pub op_state: SensorOperationalState,
+    pub present_state: u8,
+    pub previous_state: u8,
+    pub event_state: u8,
+}
+
+impl StateField {
+    pub fn debug_state_set(&self, state_set: u16) -> StateFieldDebug<'_> {
+        StateFieldDebug {
+            inner: self,
+            state_set,
+        }
+    }
+}
+
+pub struct StateDebug<T: FromPrimitive + Debug> {
+    state: u8,
+    state_set: PhantomData<T>,
+}
+
+impl<T: FromPrimitive + Debug> StateDebug<T> {
+    fn new(state: u8) -> Self {
+        Self {
+            state,
+            state_set: PhantomData,
+        }
+    }
+}
+
+impl<T: FromPrimitive + Debug> Debug for StateDebug<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if let Some(v) = T::from_u8(self.state) {
+            write!(f, "{} {:?}", self.state, &v)
+        } else {
+            write!(f, "{} (unrecognised state)", self.state)
+        }
+    }
+}
+
+/// Print debug formatting with a given StateSet value `T`.
+///
+/// Will print u8 version for unknown state set.
+pub struct StateFieldDebug<'a> {
+    inner: &'a StateField,
+    state_set: u16,
+}
+
+impl StateFieldDebug<'_> {
+    pub fn debug_from_u8<T: FromPrimitive + Debug>(
+        &self,
+        f: &mut core::fmt::Formatter,
+    ) -> core::fmt::Result {
+        f.debug_struct("StateField")
+            .field("op_state", &self.inner.op_state)
+            .field(
+                "present_state",
+                &StateDebug::<T>::new(self.inner.present_state),
+            )
+            .field(
+                "previous_state",
+                &StateDebug::<T>::new(self.inner.previous_state),
+            )
+            .field(
+                "event_state",
+                &StateDebug::<T>::new(self.inner.present_state),
+            )
+            .finish()
+    }
+}
+
+impl Debug for StateFieldDebug<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use crate::state_sets::*;
+        match self.state_set {
+            OperationFaultStatus::ID => {
+                self.debug_from_u8::<OperationFaultStatus>(f)
+            }
+            DeviceInitialization::ID => {
+                self.debug_from_u8::<DeviceInitialization>(f)
+            }
+            HardwareSecurity::ID => self.debug_from_u8::<HardwareSecurity>(f),
+            _ => {
+                debug!("Unrecognised state set {:#04x}", self.state_set);
+                write!(f, "{:?}", self.inner)
+            }
+        }
+    }
+}
+
+#[deku_derive(DekuRead, DekuWrite)]
+#[derive(Debug, Clone)]
+pub struct GetStateSensorReadingsResp {
+    #[deku(temp, temp_value = "self.fields.len() as u8")]
+    pub composite_sensor_count: u8,
+    #[deku(count = "composite_sensor_count")]
+    pub fields: VecWrap<StateField, 8>,
+}
+
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
+pub struct SetNumericSensorEnableReq {
+    pub sensor: SensorId,
+    pub set_op_state: SetSensorOperationalState,
+    pub event_enable: SensorEventMessageEnable,
+}
+
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
+pub struct SetEnableField {
+    pub set_op_state: SetSensorOperationalState,
+    pub event_enable: SensorEventMessageEnable,
+}
+
+#[deku_derive(DekuRead, DekuWrite)]
+#[derive(Debug, Clone)]
+pub struct SetStateSensorEnablesReq {
+    pub sensor: SensorId,
+
+    #[deku(temp, temp_value = "self.fields.len() as u8")]
+    pub composite_sensor_count: u8,
+
+    #[deku(count = "composite_sensor_count")]
+    pub fields: VecWrap<SetEnableField, 8>,
+}

--- a/pldm-platform/src/requester.rs
+++ b/pldm-platform/src/requester.rs
@@ -292,5 +292,13 @@ pub async fn get_pdr(
         return Err(proto_error!("PDR unknown version"));
     }
 
+    let expect_len = pdrrsp.record_data.len() - 10;
+    if pdr.data_length as usize != expect_len {
+        warn!(
+            "Incorrect PDR data_length, got {}, expect {}",
+            pdr.data_length, expect_len
+        );
+    }
+
     Ok(pdr.record)
 }

--- a/pldm-platform/src/requester.rs
+++ b/pldm-platform/src/requester.rs
@@ -1,0 +1,211 @@
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+use pldm::CCode;
+
+use num_traits::FromPrimitive;
+
+use crate::proto::*;
+use crate::PLDM_TYPE_PLATFORM;
+use pldm::{pldm_xfer_buf, proto_error, PldmError, PldmRequest, Result};
+
+use deku::{DekuContainerRead, DekuContainerWrite};
+
+use heapless::Vec;
+
+/// Reads a numeric sensor.
+pub fn get_sensor_reading(
+    comm: &mut impl mctp::ReqChannel,
+    sensor: SensorId,
+    rearm: bool,
+) -> Result<GetSensorReadingResp> {
+    let r = GetSensorReadingReq { sensor, rearm };
+
+    let mut buf = [0; 10];
+    let l = r.to_slice(&mut buf).map_err(|_| PldmError::NoSpace)?;
+    let buf = &buf[..l];
+
+    let req = PldmRequest::new_borrowed(
+        PLDM_TYPE_PLATFORM,
+        Cmd::GetSensorReading as u8,
+        buf,
+    );
+
+    let mut rx = [0; 30];
+    let resp = pldm_xfer_buf(comm, req, &mut rx)?;
+
+    let ((rest, _), ret) = GetSensorReadingResp::from_bytes((&resp.data, 0))
+        .map_err(|e| {
+            trace!("GetSensorReading parse error {e}");
+            proto_error!("Bad GetSensorReading response")
+        })?;
+
+    if !rest.is_empty() {
+        return Err(proto_error!("Extra response"));
+    }
+
+    Ok(ret)
+}
+
+/// Reads a simple state sensor.
+///
+/// Reads sensor offset 0.
+pub fn get_simple_state_sensor_reading(
+    comm: &mut impl mctp::ReqChannel,
+    sensor: SensorId,
+    rearm: bool,
+) -> Result<StateField> {
+    let r = GetStateSensorReadingsReq {
+        sensor,
+        rearm: rearm as u8,
+    };
+
+    let mut buf = [0; 10];
+    let l = r.to_slice(&mut buf).map_err(|_| PldmError::NoSpace)?;
+    let buf = &buf[..l];
+
+    let req = PldmRequest::new_borrowed(
+        PLDM_TYPE_PLATFORM,
+        Cmd::GetStateSensorReadings as u8,
+        buf,
+    );
+
+    let mut rx = [0; 50];
+    let resp = pldm_xfer_buf(comm, req, &mut rx)?;
+
+    match CCode::from_u8(resp.cc) {
+        Some(CCode::SUCCESS) => (),
+        Some(e) => {
+            return Err(proto_error!("Error response", "{e:?}"));
+        }
+        None if resp.cc == INVALID_SENSOR_ID => {
+            return Err(proto_error!("Invalid Sensor ID"));
+        }
+        None => return Err(proto_error!("Error", "{}", resp.cc)),
+    }
+
+    let ((rest, _), mut ret) = GetStateSensorReadingsResp::from_bytes((
+        &resp.data, 0,
+    ))
+    .map_err(|e| {
+        trace!("GetStateSensorReadings parse error {e}");
+        proto_error!("Bad GetStateSensorReadings response")
+    })?;
+
+    if !rest.is_empty() {
+        return Err(proto_error!("Extra response"));
+    }
+
+    if ret.fields.len() != 1 {
+        return Err(proto_error!("Incorrect sensor count"));
+    }
+
+    Ok(ret.fields.swap_remove(0))
+}
+
+/// SetNumericSensorEnable
+///
+/// `op_event_enable` and `state_event_enable` are ignored if `event_no_change` is set.
+pub fn set_numeric_sensor_enable(
+    comm: &mut impl mctp::ReqChannel,
+    sensor: SensorId,
+    set_op_state: SetSensorOperationalState,
+    event_no_change: bool,
+    op_event_enable: bool,
+    state_event_enable: bool,
+) -> Result<()> {
+    let event_enable = if event_no_change {
+        SensorEventMessageEnable::NoEventGeneration
+    } else {
+        SensorEventMessageEnable::new(op_event_enable, state_event_enable)
+    };
+
+    let r = SetNumericSensorEnableReq {
+        sensor,
+        set_op_state,
+        event_enable,
+    };
+
+    let mut buf = [0; 10];
+    let l = r.to_slice(&mut buf).map_err(|_| PldmError::NoSpace)?;
+    let buf = &buf[..l];
+
+    let req = PldmRequest::new_borrowed(
+        PLDM_TYPE_PLATFORM,
+        Cmd::SetNumericSensorEnable as u8,
+        buf,
+    );
+
+    let mut rx = [0; 50];
+    let resp = pldm_xfer_buf(comm, req, &mut rx)?;
+
+    match CCode::from_u8(resp.cc) {
+        Some(CCode::SUCCESS) => (),
+        Some(e) => {
+            return Err(proto_error!("Error response", "{e:?}"));
+        }
+        None if resp.cc == INVALID_SENSOR_ID => {
+            return Err(proto_error!("Invalid Sensor ID"));
+        }
+        None if resp.cc == EVENT_GENERATION_NOT_SUPPORTED => {
+            return Err(proto_error!("Event generation not supported"));
+        }
+        None => return Err(proto_error!("Error", "{}", resp.cc)),
+    }
+
+    Ok(())
+}
+
+/// SetStateSensorEnables
+///
+/// Sets field 0 of a sensor.
+/// `op_event_enable` and `state_event_enable` are ignored if `event_no_change` is set.
+pub fn set_simple_state_sensor_enables(
+    comm: &mut impl mctp::ReqChannel,
+    sensor: SensorId,
+    set_op_state: SetSensorOperationalState,
+    event_no_change: bool,
+    op_event_enable: bool,
+    state_event_enable: bool,
+) -> Result<()> {
+    let event_enable = if event_no_change {
+        SensorEventMessageEnable::NoEventGeneration
+    } else {
+        SensorEventMessageEnable::new(op_event_enable, state_event_enable)
+    };
+
+    let f = SetEnableField {
+        set_op_state,
+        event_enable,
+    };
+    let fields = Vec::from_slice(&[f]).unwrap().into();
+    let r = SetStateSensorEnablesReq { sensor, fields };
+
+    let mut buf = [0; 10];
+    let l = r.to_slice(&mut buf).map_err(|_| PldmError::NoSpace)?;
+    let buf = &buf[..l];
+
+    let req = PldmRequest::new_borrowed(
+        PLDM_TYPE_PLATFORM,
+        Cmd::SetStateSensorEnables as u8,
+        buf,
+    );
+
+    let mut rx = [0; 50];
+    let resp = pldm_xfer_buf(comm, req, &mut rx)?;
+
+    match CCode::from_u8(resp.cc) {
+        Some(CCode::SUCCESS) => (),
+        Some(e) => {
+            return Err(proto_error!("Error response", "{e:?}"));
+        }
+        None if resp.cc == INVALID_SENSOR_ID => {
+            return Err(proto_error!("Invalid Sensor ID"));
+        }
+        None if resp.cc == EVENT_GENERATION_NOT_SUPPORTED => {
+            return Err(proto_error!("Event generation not supported"));
+        }
+        None => return Err(proto_error!("Error", "{}", resp.cc)),
+    }
+
+    Ok(())
+}

--- a/pldm-platform/src/state_sets.rs
+++ b/pldm-platform/src/state_sets.rs
@@ -1,0 +1,45 @@
+/// PLDM State Set definitions.
+/// From DSP0249. Only contains a subset at present.
+use num_derive::FromPrimitive;
+
+#[allow(missing_docs)]
+#[derive(FromPrimitive, Debug, PartialEq, Eq, Copy, Clone)]
+#[repr(u8)]
+pub enum OperationFaultStatus {
+    Unknown = 0,
+    Normal,
+    Error,
+    NonRecoverableError,
+}
+
+impl OperationFaultStatus {
+    pub const ID: u16 = 10;
+}
+
+#[allow(missing_docs)]
+#[derive(FromPrimitive, Debug, PartialEq, Eq, Copy, Clone)]
+#[repr(u8)]
+pub enum DeviceInitialization {
+    Unknown = 0,
+    Normal,
+    InitializationInProgress,
+    InitializationHung,
+    InitializationFailed,
+}
+
+impl DeviceInitialization {
+    pub const ID: u16 = 20;
+}
+
+#[allow(missing_docs)]
+#[derive(FromPrimitive, Debug, PartialEq, Eq, Copy, Clone)]
+#[repr(u8)]
+pub enum HardwareSecurity {
+    Unknown = 0,
+    HardwareSecurityVerified,
+    HardwareSecurityUnverified,
+}
+
+impl HardwareSecurity {
+    pub const ID: u16 = 99;
+}

--- a/pldm/Cargo.toml
+++ b/pldm/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
+crc = "3.0"
+deku = { workspace = true }
+heapless = { workspace = true }
 mctp = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/pldm/Cargo.toml
+++ b/pldm/Cargo.toml
@@ -15,6 +15,8 @@ mctp = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 
+log = "0.4"
+
 [features]
 default = ["std"]
 alloc = []

--- a/pldm/src/control.rs
+++ b/pldm/src/control.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * PLDM Messaging Control and Discovery ("PLDM Control") definitions.
+ *
+ * Copyright (c) 2025 Code Construct
+ */
+
+//! PLDM Messaging Control and Discovery ("PLDM Control" / type 0) messaging
+//! support.
+//!
+//! This module provides definitions for PLDM control requests and responses.
+
+use crate::{proto_error, PldmError, Result};
+
+/// PLDM Control command codes
+#[allow(missing_docs)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum Cmd {
+    SetTID = 0x01,
+    GetTID = 0x02,
+    GetPLDMVersion = 0x03,
+    GetPLDMTypes = 0x04,
+    GetPLDMCommands = 0x05,
+    SelectPLDMVersion = 0x06,
+    NegotiateTransferParameters = 0x07,
+    MultipartSend = 0x08,
+    MultipartReceive = 0x09,
+}
+
+impl TryFrom<u8> for Cmd {
+    type Error = PldmError;
+
+    fn try_from(value: u8) -> Result<Self> {
+        let c = match value {
+            0x01 => Self::SetTID,
+            0x02 => Self::GetTID,
+            0x03 => Self::GetPLDMVersion,
+            0x04 => Self::GetPLDMTypes,
+            0x05 => Self::GetPLDMCommands,
+            0x06 => Self::SelectPLDMVersion,
+            0x07 => Self::NegotiateTransferParameters,
+            0x08 => Self::MultipartSend,
+            0x09 => Self::MultipartReceive,
+            v => {
+                let _ = v;
+                return Err(proto_error!(
+                    "Unknown PLDM base command",
+                    "{v:02x}"
+                ));
+            }
+        };
+        Ok(c)
+    }
+}

--- a/pldm/src/control.rs
+++ b/pldm/src/control.rs
@@ -21,6 +21,7 @@ pub mod responder;
 pub const PLDM_TYPE_CONTROL: u8 = 0;
 
 /// PLDM Control command codes
+#[derive(Debug)]
 #[allow(missing_docs)]
 #[repr(u8)]
 #[non_exhaustive]
@@ -96,21 +97,21 @@ impl TryFrom<u8> for Cmd {
 }
 
 /// Set TID request
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 pub struct SetTIDReq {
     /// TID
     pub tid: u8,
 }
 
 /// Get TID response
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 pub struct GetTIDResp {
     /// TID
     pub tid: u8,
 }
 
 /// Get PLDM Version request
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct GetPLDMVersionReq {
     /// DataTransferHandle
@@ -122,7 +123,7 @@ pub struct GetPLDMVersionReq {
 }
 
 /// Get PLDM Version response
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct GetPLDMVersionResp {
     /// NextDataTransferHandle
@@ -136,14 +137,14 @@ pub struct GetPLDMVersionResp {
 }
 
 /// Get PLDM Types response
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 pub struct GetPLDMTypesResp {
     /// PLDM Types bitmask
     pub types: [u8; 8],
 }
 
 /// Get PLDM Commands request
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct GetPLDMCommandsReq {
     /// PLDMType
@@ -153,14 +154,14 @@ pub struct GetPLDMCommandsReq {
 }
 
 /// Get PLDM Commands response
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 pub struct GetPLDMCommandsResp {
     /// PLDM Types bitmask
     pub commands: [u8; 32],
 }
 
 /// Negotiate Transfer Parameters request
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct NegotiateTransferParametersReq {
     /// RequesterPartSize.
@@ -175,7 +176,7 @@ pub struct NegotiateTransferParametersReq {
 }
 
 /// Negotiate Transfer Parameters response
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct NegotiateTransferParametersResp {
     /// ResponderPartSize.
@@ -190,7 +191,7 @@ pub struct NegotiateTransferParametersResp {
 }
 
 /// Multipart Receive request
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct MultipartReceiveReq {
     /// PLDM type
@@ -208,7 +209,7 @@ pub struct MultipartReceiveReq {
 }
 
 /// Multipart Receive response
-#[derive(DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "little")]
 pub struct MultipartReceiveResp {
     /// Transfer flag

--- a/pldm/src/control.rs
+++ b/pldm/src/control.rs
@@ -44,6 +44,29 @@ pub mod control_ccode {
     pub const INVALID_PLDM_VERSION_IN_REQUEST_DATA: u8 = 0x84;
 }
 
+/// Multipart transfer operation values
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub mod xfer_op {
+    pub const FIRST_PART: u8 = 0;
+    pub const NEXT_PART: u8 = 1;
+    pub const ABORT: u8 = 2;
+    pub const COMPLETE: u8 = 3;
+    pub const CURRENT_PART: u8 = 4;
+}
+
+/// Transfer flag values
+#[allow(missing_docs)]
+#[allow(non_camel_case_types)]
+pub mod xfer_flag {
+    pub const START: u8 = 1;
+    pub const MIDDLE: u8 = 2;
+    pub const END: u8 = 4;
+    // Provided by the spec....
+    pub const START_AND_END: u8 = START | END;
+    pub const ACKNOWLEDGE_COMPLETION: u8 = 8;
+}
+
 impl TryFrom<u8> for Cmd {
     type Error = PldmError;
 
@@ -132,4 +155,34 @@ pub struct GetPLDMCommandsReq {
 pub struct GetPLDMCommandsResp {
     /// PLDM Types bitmask
     pub commands: [u8; 32],
+}
+
+/// Multipart Receive request
+#[derive(DekuRead, DekuWrite)]
+#[deku(endian = "little")]
+pub struct MultipartReceiveReq {
+    /// PLDM type
+    pub pldm_type: u8,
+    /// Transfer operation
+    pub xfer_op: u8,
+    /// Transfer context identifier
+    pub xfer_context: u32,
+    /// Transfer handle for this receive request
+    pub xfer_handle: u32,
+    /// Requested offset
+    pub req_offset: u32,
+    /// Requested length
+    pub req_length: u32,
+}
+
+/// Multipart Receive response
+#[derive(DekuRead, DekuWrite)]
+#[deku(endian = "little")]
+pub struct MultipartReceiveResp {
+    /// Transfer flag
+    pub xfer_flag: u8,
+    /// Next transfer handle
+    pub next_handle: u32,
+    /// Data length
+    pub len: u32,
 }

--- a/pldm/src/control.rs
+++ b/pldm/src/control.rs
@@ -42,6 +42,7 @@ pub mod control_ccode {
     pub const INVALID_TRANSFER_OPERATION_FLAG: u8 = 0x81;
     pub const INVALID_PLDM_TYPE_IN_REQUEST_DATA: u8 = 0x83;
     pub const INVALID_PLDM_VERSION_IN_REQUEST_DATA: u8 = 0x84;
+    pub const NEGOTIATION_INCOMPLETE: u8 = 0x83;
 }
 
 /// Multipart transfer operation values
@@ -155,6 +156,36 @@ pub struct GetPLDMCommandsReq {
 pub struct GetPLDMCommandsResp {
     /// PLDM Types bitmask
     pub commands: [u8; 32],
+}
+
+/// Negotiate Transfer Parameters request
+#[derive(DekuRead, DekuWrite)]
+#[deku(endian = "little")]
+pub struct NegotiateTransferParametersReq {
+    /// RequesterPartSize.
+    ///
+    /// Maximum transfer size supported by the requester
+    pub part_size: u16,
+
+    /// Requester Protocol Support
+    ///
+    /// Bitmask of PLDM protocols implementing multipart transfer
+    pub protocols: [u8; 8],
+}
+
+/// Negotiate Transfer Parameters response
+#[derive(DekuRead, DekuWrite)]
+#[deku(endian = "little")]
+pub struct NegotiateTransferParametersResp {
+    /// ResponderPartSize.
+    ///
+    /// Negotiated transfer size
+    pub part_size: u16,
+
+    /// Responder Protocol Support
+    ///
+    /// Bitmask of negotiated PLDM protocols implementing multipart transfer
+    pub protocols: [u8; 8],
 }
 
 /// Multipart Receive request

--- a/pldm/src/control.rs
+++ b/pldm/src/control.rs
@@ -14,6 +14,7 @@ use deku::{DekuRead, DekuWrite};
 
 use crate::{proto_error, PldmError, Result};
 
+pub mod requester;
 pub mod responder;
 
 /// PLDM Messaging Control and Discovery type

--- a/pldm/src/control/requester.rs
+++ b/pldm/src/control/requester.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * PLDM base responder implementation.
+ *
+ * Copyright (c) 2025 Code Construct
+ */
+
+//! PLDM base protocol requester support
+#[allow(unused_imports)]
+use log::{debug, error, info, trace, warn};
+
+use mctp::AsyncReqChannel;
+
+use deku::prelude::*;
+
+use crate::{
+    ccode_result, control, pldm_xfer_buf_async, proto_error, util::SliceWriter,
+    PldmError, PldmRequest, PldmResult,
+};
+
+use super::xfer_flag;
+
+/// Perform a Set TID request.
+pub async fn set_tid(
+    comm: &mut impl AsyncReqChannel,
+    tid: u8,
+) -> PldmResult<()> {
+    let mut buf = [0u8; 1];
+    let msg = control::SetTIDReq { tid };
+    let l = msg.to_slice(&mut buf)?;
+    let req = PldmRequest::new_borrowed(
+        control::PLDM_TYPE_CONTROL,
+        control::Cmd::SetTID as u8,
+        &buf[..l],
+    );
+
+    let mut rx_buf = [0u8; 4];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx_buf).await?;
+
+    ccode_result(resp.cc)
+}
+
+/// Perform a Get TID request.
+pub async fn get_tid(comm: &mut impl AsyncReqChannel) -> PldmResult<u8> {
+    let req = PldmRequest::new_borrowed(
+        control::PLDM_TYPE_CONTROL,
+        control::Cmd::GetTID as u8,
+        &[],
+    );
+
+    let mut rx_buf = [0u8; 5];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx_buf).await?;
+
+    ccode_result(resp.cc)?;
+
+    let ((rest, _), tidrsp) = control::GetTIDResp::from_bytes((&resp.data, 0))?;
+
+    if !rest.is_empty() {
+        // TODO
+        warn!("Extra get TID response");
+    }
+
+    Ok(tidrsp.tid)
+}
+
+/// Perform a Get PLDM Version request.
+pub async fn get_pldm_version<'f>(
+    comm: &mut impl AsyncReqChannel,
+    pldm_type: u8,
+    ret_buf: &'f mut [u32],
+) -> PldmResult<&'f [u32]> {
+    let mut buf = [0u8; 6];
+    let msg = control::GetPLDMVersionReq {
+        xfer_handle: 0,
+        // Get first part
+        xfer_op: 1,
+        pldm_type,
+    };
+    let l = msg.to_slice(&mut buf)?;
+    let req = PldmRequest::new_borrowed(
+        control::PLDM_TYPE_CONTROL,
+        control::Cmd::GetPLDMVersion as u8,
+        &buf[..l],
+    );
+
+    let mut rx_buf = [0u8; 50];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx_buf).await?;
+
+    ccode_result(resp.cc)?;
+
+    let ((rest, _), vrsp) =
+        control::GetPLDMVersionResp::from_bytes((&resp.data, 0))?;
+
+    if !rest.is_empty() {
+        // TODO
+        warn!("Extra get version response");
+    }
+
+    // Require StartAndEnd
+    if vrsp.xfer_flag != xfer_flag::START_AND_END {
+        // TODO
+        return Err(proto_error!("Can't handle parts"));
+    }
+
+    let Some(r) = ret_buf.get_mut(..1) else {
+        return Err(proto_error!("Short ret_buf"));
+    };
+    r[0] = vrsp.version;
+    Ok(r)
+}
+
+/// Perform a Get PLDM Types request.
+pub async fn get_pldm_types<'f>(
+    comm: &mut impl AsyncReqChannel,
+    ret_buf: &'f mut [u8],
+) -> PldmResult<&'f [u8]> {
+    let req = PldmRequest::new_borrowed(
+        control::PLDM_TYPE_CONTROL,
+        control::Cmd::GetPLDMTypes as u8,
+        &[],
+    );
+
+    let mut rx_buf = [0u8; 70];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx_buf).await?;
+
+    ccode_result(resp.cc)?;
+
+    let ((rest, _), vty) =
+        control::GetPLDMTypesResp::from_bytes((&resp.data, 0))?;
+
+    if !rest.is_empty() {
+        // TODO
+        warn!("Extra get types response");
+    }
+
+    let mut ret = SliceWriter::new(ret_buf);
+    for t in 0..64 {
+        if vty.types[t / 8] & (1 << (t % 8)) != 0 {
+            ret.push_le(t as u8).ok_or(PldmError::NoSpace)?;
+        }
+    }
+
+    Ok(ret.done())
+}
+
+/// Perform a Get PLDM Commands request.
+pub async fn get_pldm_commands<'f>(
+    comm: &mut impl AsyncReqChannel,
+    pldm_type: u8,
+    version: u32,
+    ret_buf: &'f mut [u8],
+) -> PldmResult<&'f [u8]> {
+    let mut buf = [0u8; 5];
+    let msg = control::GetPLDMCommandsReq { pldm_type, version };
+    let l = msg.to_slice(&mut buf)?;
+    let req = PldmRequest::new_borrowed(
+        control::PLDM_TYPE_CONTROL,
+        control::Cmd::GetPLDMCommands as u8,
+        &buf[..l],
+    );
+
+    let mut rx_buf = [0u8; 36];
+    let resp = pldm_xfer_buf_async(comm, req, &mut rx_buf).await?;
+
+    ccode_result(resp.cc)?;
+
+    let ((rest, _), cmdrsp) =
+        control::GetPLDMCommandsResp::from_bytes((&resp.data, 0))?;
+
+    if !rest.is_empty() {
+        // TODO
+        warn!("Extra get commands response");
+    }
+
+    let mut ret = SliceWriter::new(ret_buf);
+    for t in 0..256 {
+        if cmdrsp.commands[t / 8] & (1 << (t % 8)) != 0 {
+            ret.push_le(t as u8).ok_or(PldmError::NoSpace)?;
+        }
+    }
+
+    Ok(ret.done())
+}

--- a/pldm/src/control/responder.rs
+++ b/pldm/src/control/responder.rs
@@ -13,7 +13,7 @@
 
 use deku::{DekuContainerRead, DekuContainerWrite, DekuError};
 use heapless::Vec;
-use mctp::AsyncRespChannel;
+use mctp::{AsyncRespChannel, Eid};
 
 use crate::control::{self, control_ccode, Cmd, PLDM_TYPE_CONTROL};
 use crate::{
@@ -27,14 +27,22 @@ pub const TID_UNASSIGNED: u8 = 0x00;
 struct TypeData {
     id: u8,
     version: u32,
+    // stored as log2
+    multipart_size: Option<u8>,
     commands: [u8; 32],
 }
 
 impl TypeData {
-    fn new(id: u8, version: u32, commands: &[u8]) -> Self {
+    fn new(
+        id: u8,
+        version: u32,
+        multipart_size: Option<u8>,
+        commands: &[u8],
+    ) -> Self {
         let mut t = Self {
             id,
             version,
+            multipart_size,
             commands: [0u8; 32],
         };
         for c in commands {
@@ -47,6 +55,19 @@ impl TypeData {
     }
 }
 
+// number of peers that we track negotiated parameters against.
+const N_PEERS: usize = 8;
+
+// per-peer data on Negotiate Transfer Parameters results.
+//
+// The current implementation is spec-volatingly basic: we don't handle per-type
+// data, but just update our negotiated size across all types.
+struct NegotiatedTransfer {
+    eid: Eid,
+    // log2(size)
+    size: u8,
+}
+
 /// Responder object for PLDM Messaging Control and Discovery (type 0) commands.
 ///
 /// The N const represents the number of PLDM subtype slots that we support.
@@ -56,6 +77,9 @@ pub struct Responder<const N: usize> {
     types: Vec<TypeData, N>,
     // we can get our base PLDM responses into a single MCTP BTU
     buf: [u8; 64],
+
+    // negotiated sizes for each peer
+    negotiations: Vec<NegotiatedTransfer, N_PEERS>,
 }
 
 struct PldmCommandError(u8);
@@ -92,10 +116,12 @@ impl<const N: usize> Responder<N> {
             tid: TID_UNASSIGNED,
             types: Vec::new(),
             buf: [0u8; 64],
+            negotiations: Vec::new(),
         };
         let t = TypeData::new(
             0,
             0xf1f1f000,
+            None,
             &[Cmd::SetTID as u8, Cmd::GetTID as u8],
         );
         let _ = r.types.push(t);
@@ -110,11 +136,39 @@ impl<const N: usize> Responder<N> {
         &mut self,
         id: u8,
         version: u32,
+        multipart_size: Option<u16>,
         commands: &[u8],
     ) -> Result<()> {
-        let typ = TypeData::new(id, version, commands);
+        if id >= 64 {
+            Err(PldmError::InvalidArgument)?;
+        }
+        let log2_sz = match multipart_size {
+            Some(sz) => {
+                if sz < 256 || !sz.is_power_of_two() {
+                    Err(PldmError::InvalidArgument)?;
+                }
+                Some(sz.ilog2() as u8)
+            }
+            None => None,
+        };
+        let typ = TypeData::new(id, version, log2_sz, commands);
         self.types.push(typ).map_err(|_| PldmError::NoSpace)?;
         Ok(())
+    }
+
+    /// Query the previously-negotiated transfer size for the given EID
+    /// and PLDM type
+    ///
+    /// Returns None if no negotiation has occurred
+    pub fn negotiated_xfer_size(
+        &self,
+        peer: Eid,
+        _pldm_type: u8,
+    ) -> Option<u16> {
+        self.negotiations
+            .iter()
+            .find(|n| n.eid == peer)
+            .map(|n| 1 << n.size)
     }
 
     /// Handle an incoming PLDM Messaging Control and Discovery request
@@ -127,12 +181,17 @@ impl<const N: usize> Responder<N> {
             return Err(proto_error!("Unexpected pldm control request"));
         }
 
+        let eid = resp_chan.remote_eid();
+
         let res = match Cmd::try_from(req.cmd) {
             Ok(Cmd::SetTID) => self.cmd_set_tid(req),
             Ok(Cmd::GetTID) => self.cmd_get_tid(req),
             Ok(Cmd::GetPLDMVersion) => self.cmd_get_version(req),
             Ok(Cmd::GetPLDMTypes) => self.cmd_get_types(req),
             Ok(Cmd::GetPLDMCommands) => self.cmd_get_commands(req),
+            Ok(Cmd::NegotiateTransferParameters) => {
+                self.cmd_negotiate_transfer_parameters(req, eid)
+            }
             _ => Err(CCode::ERROR_UNSUPPORTED_PLDM_CMD.into()),
         };
 
@@ -245,6 +304,66 @@ impl<const N: usize> Responder<N> {
 
         let resp = control::GetPLDMCommandsResp {
             commands: typ.commands,
+        };
+
+        let len = resp.to_slice(&mut self.buf)?;
+        let resp = req.response_borrowed(&self.buf[0..len]);
+        Ok(resp)
+    }
+
+    fn cmd_negotiate_transfer_parameters(
+        &mut self,
+        req: &PldmRequest,
+        eid: Eid,
+    ) -> PldmCommandResult<PldmResponse<'_>> {
+        let data = &req.data;
+        let (_rest, nreq) =
+            control::NegotiateTransferParametersReq::from_bytes((
+                data,
+                data.len(),
+            ))?;
+
+        let req_size = nreq.part_size;
+        if !req_size.is_power_of_two() || req_size < 256 {
+            Err(CCode::ERROR_INVALID_DATA)?;
+        }
+
+        let req_size = req_size.ilog2() as u8;
+        let mut neg_size = req_size;
+
+        let req_types = u64::from_le_bytes(nreq.protocols);
+        let mut neg_types = 0u64;
+
+        for t in &self.types {
+            if t.id >= 64 {
+                continue;
+            }
+            let mask = 1 << t.id;
+            if req_types & mask == 0 {
+                continue;
+            }
+            if let Some(sz) = t.multipart_size {
+                neg_types |= mask;
+                neg_size = neg_size.min(sz);
+            }
+        }
+
+        let negotiation = self.negotiations.iter_mut().find(|n| n.eid == eid);
+
+        match negotiation {
+            Some(n) => n.size = neg_size,
+            None => {
+                let n = NegotiatedTransfer {
+                    eid,
+                    size: neg_size,
+                };
+                self.negotiations.push(n).map_err(|_| CCode::ERROR)?;
+            }
+        }
+
+        let resp = control::NegotiateTransferParametersResp {
+            part_size: 1u16 << req_size,
+            protocols: neg_types.to_le_bytes(),
         };
 
         let len = resp.to_slice(&mut self.buf)?;

--- a/pldm/src/control/responder.rs
+++ b/pldm/src/control/responder.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * PLDM base responder implementation.
+ *
+ * Copyright (c) 2025 Code Construct
+ */
+
+//! Platform Level Data Model (PLDM) base protocol responder support
+//!
+//! Using structures from the core PLDM support, implement a simple
+//! responder that handles base commands, maintaining core PLDM state, mostly
+//! for enumerating subtype responders on this endpoint.
+
+use deku::{DekuContainerRead, DekuContainerWrite, DekuError};
+use heapless::Vec;
+use mctp::AsyncRespChannel;
+
+use crate::control::{self, control_ccode, Cmd, PLDM_TYPE_CONTROL};
+use crate::{
+    pldm_tx_resp_async, proto_error, CCode, PldmError, PldmRequest,
+    PldmResponse, Result,
+};
+
+/// Unassigned terminus ID
+pub const TID_UNASSIGNED: u8 = 0x00;
+
+struct TypeData {
+    id: u8,
+    version: u32,
+    commands: [u8; 32],
+}
+
+impl TypeData {
+    fn new(id: u8, version: u32, commands: &[u8]) -> Self {
+        let mut t = Self {
+            id,
+            version,
+            commands: [0u8; 32],
+        };
+        for c in commands {
+            let idx = *c as usize / 8;
+            let offs = c % 8;
+
+            t.commands[idx] |= 1 << offs;
+        }
+        t
+    }
+}
+
+/// Responder object for PLDM Messaging Control and Discovery (type 0) commands.
+///
+/// The N const represents the number of PLDM subtype slots that we support.
+/// The type-0 handler itself consumes one slot.
+pub struct Responder<const N: usize> {
+    tid: u8,
+    types: Vec<TypeData, N>,
+    // we can get our base PLDM responses into a single MCTP BTU
+    buf: [u8; 64],
+}
+
+struct PldmCommandError(u8);
+
+impl From<CCode> for PldmCommandError {
+    fn from(value: CCode) -> Self {
+        Self(value as u8)
+    }
+}
+
+impl From<u8> for PldmCommandError {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DekuError> for PldmCommandError {
+    fn from(err: DekuError) -> Self {
+        let cc = match err {
+            DekuError::Incomplete(_) => CCode::ERROR_INVALID_LENGTH,
+            DekuError::Parse(_) => CCode::ERROR_INVALID_DATA,
+            _ => CCode::ERROR,
+        };
+        Self(cc as u8)
+    }
+}
+
+type PldmCommandResult<T> = core::result::Result<T, PldmCommandError>;
+
+impl<const N: usize> Responder<N> {
+    /// Create a new responder.
+    pub fn new() -> Self {
+        let mut r = Self {
+            tid: TID_UNASSIGNED,
+            types: Vec::new(),
+            buf: [0u8; 64],
+        };
+        let t = TypeData::new(
+            0,
+            0xf1f1f000,
+            &[Cmd::SetTID as u8, Cmd::GetTID as u8],
+        );
+        let _ = r.types.push(t);
+        r
+    }
+
+    /// Resgister a new PLDM type with this responder.
+    ///
+    /// This populates data returned by the base Get PLDM Types, Get PLDM
+    /// Versions and Get PLDM Commands responses.
+    pub fn register_type(
+        &mut self,
+        id: u8,
+        version: u32,
+        commands: &[u8],
+    ) -> Result<()> {
+        let typ = TypeData::new(id, version, commands);
+        self.types.push(typ).map_err(|_| PldmError::NoSpace)?;
+        Ok(())
+    }
+
+    /// Handle an incoming PLDM Messaging Control and Discovery request
+    pub async fn handle_async(
+        &mut self,
+        req: &PldmRequest<'_>,
+        mut resp_chan: impl AsyncRespChannel,
+    ) -> Result<()> {
+        if req.typ != PLDM_TYPE_CONTROL {
+            return Err(proto_error!("Unexpected pldm control request"));
+        }
+
+        let res = match Cmd::try_from(req.cmd) {
+            Ok(Cmd::SetTID) => self.cmd_set_tid(req),
+            Ok(Cmd::GetTID) => self.cmd_get_tid(req),
+            Ok(Cmd::GetPLDMVersion) => self.cmd_get_version(req),
+            Ok(Cmd::GetPLDMTypes) => self.cmd_get_types(req),
+            Ok(Cmd::GetPLDMCommands) => self.cmd_get_commands(req),
+            _ => Err(CCode::ERROR_UNSUPPORTED_PLDM_CMD.into()),
+        };
+
+        let resp = res.unwrap_or_else(|e| {
+            let mut r = req.response_borrowed(&[]);
+            r.cc = e.0;
+            r
+        });
+
+        pldm_tx_resp_async(&mut resp_chan, &resp).await
+    }
+
+    fn cmd_set_tid(
+        &mut self,
+        req: &PldmRequest,
+    ) -> PldmCommandResult<PldmResponse<'_>> {
+        let data = &req.data;
+        let (_rest, sreq) = control::SetTIDReq::from_bytes((data, data.len()))?;
+        self.tid = sreq.tid;
+
+        let resp = req.response_borrowed(&[]);
+        Ok(resp)
+    }
+
+    fn cmd_get_tid(
+        &mut self,
+        req: &PldmRequest,
+    ) -> PldmCommandResult<PldmResponse<'_>> {
+        let resp = control::GetTIDResp { tid: self.tid };
+
+        let len = resp.to_slice(&mut self.buf)?;
+        let resp = req.response_borrowed(&self.buf[0..len]);
+        Ok(resp)
+    }
+
+    fn cmd_get_version(
+        &mut self,
+        req: &PldmRequest,
+    ) -> PldmCommandResult<PldmResponse<'_>> {
+        let data = &req.data;
+        let (_rest, vreq) =
+            control::GetPLDMVersionReq::from_bytes((data, data.len()))?;
+
+        // Get First Part?
+        if vreq.xfer_op != 1 {
+            Err(control_ccode::INVALID_TRANSFER_OPERATION_FLAG)?;
+        }
+
+        let typ = self
+            .types
+            .iter()
+            .find(|t| t.id == vreq.pldm_type)
+            .ok_or(control_ccode::INVALID_PLDM_TYPE_IN_REQUEST_DATA)?;
+
+        let tmp = typ.version.to_le_bytes();
+        let crc32 = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
+        let crc = crc32.checksum(&tmp);
+
+        let resp = control::GetPLDMVersionResp {
+            next_handle: 0,
+            xfer_flag: 0x05, /* Start and End */
+            version: typ.version,
+            crc,
+        };
+
+        let len = resp.to_slice(&mut self.buf)?;
+        let resp = req.response_borrowed(&self.buf[0..len]);
+        Ok(resp)
+    }
+
+    fn cmd_get_types(
+        &mut self,
+        req: &PldmRequest,
+    ) -> PldmCommandResult<PldmResponse<'_>> {
+        let mut resp = control::GetPLDMTypesResp { types: [0u8; 8] };
+
+        for typ in &self.types {
+            let idx = typ.id as usize / 8;
+            let offs = typ.id % 8;
+            if idx >= 8 {
+                continue;
+            }
+            resp.types[idx] |= 1 << offs;
+        }
+
+        let len = resp.to_slice(&mut self.buf)?;
+        let resp = req.response_borrowed(&self.buf[0..len]);
+        Ok(resp)
+    }
+
+    fn cmd_get_commands(
+        &mut self,
+        req: &PldmRequest,
+    ) -> PldmCommandResult<PldmResponse<'_>> {
+        let data = &req.data;
+        let (_rest, creq) =
+            control::GetPLDMCommandsReq::from_bytes((data, data.len()))?;
+
+        let typ = self
+            .types
+            .iter()
+            .find(|t| t.id == creq.pldm_type)
+            .ok_or(control_ccode::INVALID_PLDM_TYPE_IN_REQUEST_DATA)?;
+
+        if typ.version != creq.version {
+            return Err(
+                control_ccode::INVALID_PLDM_VERSION_IN_REQUEST_DATA.into()
+            );
+        }
+
+        let resp = control::GetPLDMCommandsResp {
+            commands: typ.commands,
+        };
+
+        let len = resp.to_slice(&mut self.buf)?;
+        let resp = req.response_borrowed(&self.buf[0..len]);
+        Ok(resp)
+    }
+}
+
+impl<const N: usize> Default for Responder<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/pldm/src/control/responder.rs
+++ b/pldm/src/control/responder.rs
@@ -209,7 +209,7 @@ impl<const N: usize> Responder<N> {
         req: &PldmRequest,
     ) -> PldmCommandResult<PldmResponse<'_>> {
         let data = &req.data;
-        let (_rest, sreq) = control::SetTIDReq::from_bytes((data, data.len()))?;
+        let (_rest, sreq) = control::SetTIDReq::from_bytes((data, 0))?;
         self.tid = sreq.tid;
 
         let resp = req.response_borrowed(&[]);
@@ -232,8 +232,7 @@ impl<const N: usize> Responder<N> {
         req: &PldmRequest,
     ) -> PldmCommandResult<PldmResponse<'_>> {
         let data = &req.data;
-        let (_rest, vreq) =
-            control::GetPLDMVersionReq::from_bytes((data, data.len()))?;
+        let (_rest, vreq) = control::GetPLDMVersionReq::from_bytes((data, 0))?;
 
         // Get First Part?
         if vreq.xfer_op != 1 {
@@ -287,8 +286,7 @@ impl<const N: usize> Responder<N> {
         req: &PldmRequest,
     ) -> PldmCommandResult<PldmResponse<'_>> {
         let data = &req.data;
-        let (_rest, creq) =
-            control::GetPLDMCommandsReq::from_bytes((data, data.len()))?;
+        let (_rest, creq) = control::GetPLDMCommandsReq::from_bytes((data, 0))?;
 
         let typ = self
             .types
@@ -318,10 +316,7 @@ impl<const N: usize> Responder<N> {
     ) -> PldmCommandResult<PldmResponse<'_>> {
         let data = &req.data;
         let (_rest, nreq) =
-            control::NegotiateTransferParametersReq::from_bytes((
-                data,
-                data.len(),
-            ))?;
+            control::NegotiateTransferParametersReq::from_bytes((data, 0))?;
 
         let req_size = nreq.part_size;
         if !req_size.is_power_of_two() || req_size < 256 {

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -24,6 +24,7 @@ use num_derive::FromPrimitive;
 
 use mctp::MsgIC;
 
+pub mod control;
 pub mod util;
 use util::*;
 

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -141,6 +141,7 @@ pub enum CCode {
     ERROR_NOT_READY = 4,
     ERROR_UNSUPPORTED_PLDM_CMD = 5,
     ERROR_INVALID_PLDM_TYPE = 32,
+    ERROR_INVALID_TRANSFER_CONTEXT = 33,
 }
 
 /// Base PLDM request type

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -508,6 +508,7 @@ pub async fn pldm_xfer_buf_async<'buf>(
 
     let rsp = PldmResponse::from_buf_borrowed(rx_buf)?;
     check_req_resp_match(&req, &rsp)?;
+    ccode_result(rsp.cc)?;
     Ok(rsp)
 }
 

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -193,7 +193,7 @@ impl<'a> PldmRequest<'a> {
     ///
     /// Convert this request to a response, using the instance, type and command
     /// from the original request.
-    pub fn response(&self) -> PldmResponse<'_> {
+    pub fn response(&self) -> PldmResponse<'static> {
         PldmResponse {
             iid: self.iid,
             typ: self.typ,

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -4,7 +4,7 @@
  *
  * Copyright (c) 2023 Code Construct
  */
-#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
@@ -12,6 +12,12 @@
 //!
 //! This crate implements some base communication primitives for PLDM,
 //! used to construct higher-level PLDM messaging applications.
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::{format, string::String, vec::Vec};
 
 use core::fmt::{self, Debug};
 use num_derive::FromPrimitive;
@@ -77,6 +83,7 @@ type ErrStr = &'static str;
 /// Example
 ///
 /// ```
+/// extern crate alloc;
 /// # let iid = 1;
 /// # let actual_iid = 2;
 /// use pldm::proto_error;
@@ -87,10 +94,10 @@ type ErrStr = &'static str;
 #[cfg(feature = "alloc")]
 macro_rules! proto_error {
     ($msg: expr, $desc_str: expr) => {
-        $crate::PldmError::Protocol(format!("{}. {}", $msg, $desc_str))
+        $crate::PldmError::Protocol(alloc::format!("{}. {}", $msg, $desc_str))
     };
     ($msg: expr) => {
-        $crate::PldmError::Protocol(format!("{}.", $msg))
+        $crate::PldmError::Protocol(alloc::format!("{}.", $msg))
     };
 }
 

--- a/pldm/src/util.rs
+++ b/pldm/src/util.rs
@@ -6,6 +6,9 @@
 //! Helper functions
 use core::mem::size_of;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 /// Holds either an allocated `Vec` or borrowed slice.
 ///
 /// Can be constructed using `.into()` on a `Vec` (`std` feature) or `&[u8]` (always)

--- a/pldm/src/util.rs
+++ b/pldm/src/util.rs
@@ -78,7 +78,7 @@ impl<'a> SliceWriter<'a> {
     }
 
     /// Returns the written buffer
-    pub fn done(&mut self) -> &mut [u8] {
+    pub fn done(self) -> &'a mut [u8] {
         &mut self.s[..self.pos]
     }
 

--- a/pldm/src/util.rs
+++ b/pldm/src/util.rs
@@ -91,7 +91,11 @@ impl<'a> SliceWriter<'a> {
         Some(s.len())
     }
 
-    fn push_le<S>(&mut self, v: S) -> Option<usize>
+    /// Pushes a value into the output buffer, little endian.
+    ///
+    /// Returns the length written or `None` on insufficient space.
+    #[must_use]
+    pub fn push_le<S>(&mut self, v: S) -> Option<usize>
     where
         S: num_traits::ToBytes,
     {


### PR DESCRIPTION
This series adds support for the PLDM for File Transfer ("type 7") protocol.

Since type 7 is dependent on the PLDM base (type 0) and PLDM for Platform Montioring and Control (type 2), we also add support for dependent parts of those, including PLDM type registration, PLDM version reporting and multipart size negotiation.

We're primarily targeting async here, so we'll need to introduce async versions of some of the pldm transfer functions. For binary protocol parsing, we'll use deku, so introduce that as a workspace-wide dependency.

We introduce a few example utilities along the way, for some reference test support.