### PR TITLE
pldm-platform: Fix duplicate filename_length field

### DIFF
--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -196,7 +196,6 @@ fn handle_get_pdr(
             file_max_size,
             // TODO
             file_max_desc_count: 1,
-            file_name_length: file_name.len() as u8,
             file_name: file_name.into(),
             oem_file_name: Default::default(),
         }),

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -653,7 +653,6 @@ pub struct FileDescriptorPdr {
     pub file_version: u32,
     pub file_max_size: u32,
     pub file_max_desc_count: u8,
-    pub file_name_length: u8,
 
     #[deku(temp, temp_value = "self.file_name.len() as u8")]
     pub file_name_len: u8,


### PR DESCRIPTION
FileDescriptor PDRs were being encoded/decoded with an duplicated length field.