### PR TITLE
Fix oem_file_classification_name field, add AsciiString and Timestamp handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ name = "pldm-file"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "crc",
  "deku",
  "enumset",
@@ -1118,6 +1119,7 @@ dependencies = [
 name = "pldm-platform"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "deku",
  "heapless",
  "log",

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -19,6 +19,7 @@ pldm = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1.0"
+chrono = { workspace = true }
 mctp-linux = { workspace = true }
 pldm-platform = { workspace = true, features = ["alloc"] }
 smol = "2.0"

--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -173,11 +173,6 @@ fn handle_get_pdr(
         .try_into()
         .context("File size > u32")?;
 
-    // null terminated filename
-    let mut file_name = FILENAME.as_bytes().to_vec();
-    file_name.push(0x00);
-    let file_name = pldm_platform::Vec::from_slice(&file_name).unwrap();
-
     let pdr_resp = GetPDRResp::new_single(
         PDR_HANDLE,
         PdrRecord::FileDescriptor(FileDescriptorPdr {
@@ -196,7 +191,7 @@ fn handle_get_pdr(
             file_max_size,
             // TODO
             file_max_desc_count: 1,
-            file_name: file_name.into(),
+            file_name: FILENAME.try_into().expect("Filename too long"),
             oem_file_name: Default::default(),
         }),
     )?;

--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -105,12 +105,16 @@ async fn handle_platform<R: AsyncRespChannel>(
 
     let mut resp = req.response();
 
+    let update_time =
+        Timestamp104::try_from(&chrono::Local::now().fixed_offset())
+            .unwrap_or_default();
+
     resp.cc = match Cmd::try_from(req.cmd)? {
         Cmd::GetPDRRepositoryInfo => {
             let pdrinfo = GetPDRRepositoryInfoResp {
                 state: PDRRepositoryState::Available,
-                update_time: [0u8; 13],
-                oem_update_time: [0u8; 13],
+                update_time,
+                oem_update_time: Default::default(),
                 record_count: 1,
                 // TODO. "An implementation is allowed to round this number up to the nearest kilobyte (1024 bytes)."
                 repository_size: 1024,

--- a/pldm-file/examples/host.rs
+++ b/pldm-file/examples/host.rs
@@ -192,7 +192,7 @@ fn handle_get_pdr(
             // TODO
             file_max_desc_count: 1,
             file_name: FILENAME.try_into().expect("Filename too long"),
-            oem_file_name: Default::default(),
+            oem_file_classification_name: Default::default(),
         }),
     )?;
     let enc = pdr_resp.to_bytes().context("Encoding failed")?;

--- a/pldm-platform/Cargo.toml
+++ b/pldm-platform/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
+chrono = { workspace = true }
 deku = { workspace = true }
 heapless = { workspace = true }
 log = { workspace = true }

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -192,7 +192,7 @@ pub enum SensorState {
     UpperFatal,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct VecWrap<T, const N: usize>(pub heapless::Vec<T, N>);
 
 impl<T, const N: usize> From<heapless::Vec<T, N>> for VecWrap<T, N> {
@@ -261,7 +261,7 @@ where
 }
 
 /// A null terminated ascii string.
-#[derive(DekuWrite, Default, Clone)]
+#[derive(DekuWrite, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AsciiString<const N: usize>(pub VecWrap<u8, N>);
 
 impl<const N: usize> AsciiString<N> {
@@ -373,7 +373,7 @@ pub struct GetSensorReadingReq {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetSensorReadingResp {
     #[deku(temp, temp_value = "reading.deku_id().unwrap()")]
     data_size: u8,
@@ -387,7 +387,7 @@ pub struct GetSensorReadingResp {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetStateSensorReadingsReq {
     pub sensor: SensorId,
     pub rearm: u8,
@@ -395,7 +395,7 @@ pub struct GetStateSensorReadingsReq {
     rsvd: u8,
 }
 
-#[derive(Debug, DekuRead, DekuWrite, Clone)]
+#[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
 pub struct StateField {
     pub op_state: SensorOperationalState,
     pub present_state: u8,
@@ -487,7 +487,7 @@ impl Debug for StateFieldDebug<'_> {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetStateSensorReadingsResp {
     #[deku(temp, temp_value = "self.fields.len() as u8")]
     pub composite_sensor_count: u8,
@@ -495,21 +495,21 @@ pub struct GetStateSensorReadingsResp {
     pub fields: VecWrap<StateField, 8>,
 }
 
-#[derive(Debug, DekuRead, DekuWrite, Clone)]
+#[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
 pub struct SetNumericSensorEnableReq {
     pub sensor: SensorId,
     pub set_op_state: SetSensorOperationalState,
     pub event_enable: SensorEventMessageEnable,
 }
 
-#[derive(Debug, DekuRead, DekuWrite, Clone)]
+#[derive(Debug, DekuRead, DekuWrite, Clone, PartialEq, Eq)]
 pub struct SetEnableField {
     pub set_op_state: SetSensorOperationalState,
     pub event_enable: SensorEventMessageEnable,
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetStateSensorEnablesReq {
     pub sensor: SensorId,
 
@@ -534,7 +534,7 @@ pub enum PDRRepositoryState {
 pub type Timestamp104 = [u8; 13];
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetPDRRepositoryInfoResp {
     pub state: PDRRepositoryState,
     pub update_time: Timestamp104,
@@ -546,7 +546,7 @@ pub struct GetPDRRepositoryInfoResp {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[deku(id_type = "u8")]
 #[repr(u8)]
 pub enum TransferOperationFlag {
@@ -555,7 +555,7 @@ pub enum TransferOperationFlag {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetPDRReq {
     pub record_handle: u32,
     pub data_transfer_handle: u32,
@@ -567,7 +567,7 @@ pub struct GetPDRReq {
 const MAX_PDR_TRANSFER: usize = 100;
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetPDRResp {
     pub next_record_handle: u32,
     pub next_data_transfer_handle: u32,
@@ -665,7 +665,7 @@ impl deku::no_std_io::Seek for &mut Length {
 pub const PDR_VERSION_1: u8 = 1;
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pdr {
     pub record_handle: u32,
     pub pdr_header_version: u8,
@@ -681,7 +681,7 @@ pub struct Pdr {
 
 #[non_exhaustive]
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[deku(ctx = "pdr_type: u8", id = "pdr_type")]
 pub enum PdrRecord {
     #[deku(id = 30)]
@@ -697,7 +697,7 @@ impl PdrRecord {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[deku(id_type = "u8")]
 #[repr(u8)]
 pub enum FileClassification {
@@ -730,7 +730,7 @@ pub mod file_capabilities {
 }
 
 #[deku_derive(DekuRead, DekuWrite)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileDescriptorPdr {
     pub terminus_handle: u16,
     pub file_identifier: u16,

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -739,6 +739,10 @@ pub struct FileDescriptorPdr {
     pub container_id: u16,
     pub superior_directory: u16,
     pub file_classification: FileClassification,
+    /// OEM File Classification
+    ///
+    /// `oem_file_classification_name` must be `Some` if this is
+    /// non-zero (may be an empty string).
     pub oem_file_classification: u8,
     pub capabilities: u16,
     pub file_version: u32,
@@ -754,11 +758,20 @@ pub struct FileDescriptorPdr {
     #[deku(count = "file_name_len")]
     pub file_name: AsciiString<MAX_PDR_TRANSFER>,
 
-    #[deku(temp, temp_value = "self.oem_file_name.len() as u8")]
+    #[deku(skip, cond = "*oem_file_classification == 0")]
+    #[deku(
+        temp,
+        temp_value = "self.oem_file_classification_name.as_ref().map(|f| f.len()).unwrap_or(0) as u8"
+    )]
     pub oem_file_name_len: u8,
-    /// OEM file name.
+
+    /// OEM file classification name.
     ///
-    /// A null terminated string. Must be empty if `oem_file_classification == 0`.
+    /// A null terminated string. Must be `None` if `oem_file_classification == 0`.
+    #[deku(skip, cond = "*oem_file_classification == 0")]
+    #[deku(
+        assert = "(*oem_file_classification > 0) == oem_file_classification_name.is_some()"
+    )]
     #[deku(count = "oem_file_name_len")]
-    pub oem_file_name: AsciiString<MAX_PDR_TRANSFER>,
+    pub oem_file_classification_name: Option<AsciiString<MAX_PDR_TRANSFER>>,
 }


### PR DESCRIPTION
This fixes the File Descriptor response message format, as well as adding some convenience functions for displaying the filename.