### PR TITLE
mctp-estack, standalone: remove unused dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,6 @@ dependencies = [
  "log",
  "mctp",
  "proptest",
- "simplelog",
  "smbus-pec",
  "smol",
  "uuid",
@@ -886,7 +885,6 @@ dependencies = [
  "log",
  "mctp",
  "mctp-estack",
- "proptest",
  "simplelog",
  "smol",
 ]

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -23,7 +23,6 @@ uuid = { workspace = true }
 embedded-io-adapters = { workspace = true }
 env_logger =  { workspace = true }
 proptest = { workspace = true }
-simplelog = { workspace = true }
 smol = { workspace = true }
 
 [features]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -19,7 +19,6 @@ anyhow = { workspace = true }
 argh = { workspace = true}
 embedded-io-adapters = { workspace = true }
 getrandom = "0.2"
-proptest = { workspace = true }
 simplelog = { workspace = true }
 
 [features]


### PR DESCRIPTION
Found with `cargo-shear` and `cargo-udeps`.