### PR TITLE
Restructure `mctp_estack::Router`, add timeouts, add round trip tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,15 @@ jobs:
   ci:
     strategy:
       matrix:
-        # 1.82 is the earliest version that will build. Notice if it breaks,
-        # though MSRV may be bumped as needed.
-        rust_version: [stable, 1.82, nightly]
+        include:
+          - rust_version: stable
+
+          # 1.82 is the earliest version that will build. Notice if it breaks,
+          # though MSRV may be bumped as needed.
+          - rust_version: 1.82
+            no_clippy: yes
+
+          - rust_version: nightly
 
     runs-on: ubuntu-latest
 
@@ -41,4 +47,7 @@ jobs:
           rustup override set ${{ matrix.rust_version }}
 
       - name: Build and test ${{ matrix.rust_version }}
+        env:
+          # Older clippy has some unwanted lints, ignore them.
+          NO_CLIPPY: ${{ matrix.no_clippy }}
         run: ./ci/runtests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         include:
           - rust_version: stable
 
-          # 1.82 is the earliest version that will build. Notice if it breaks,
+          # 1.85 is the earliest version that will build. Notice if it breaks,
           # though MSRV may be bumped as needed.
-          - rust_version: 1.82
+          - rust_version: 1.85
             no_clippy: yes
 
           - rust_version: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -711,6 +712,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +739,17 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -750,6 +773,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -898,6 +922,7 @@ dependencies = [
  "embedded-io-adapters",
  "embedded-io-async",
  "env_logger",
+ "futures",
  "heapless",
  "log",
  "mctp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ name = "mctp-estack"
 version = "0.1.0"
 dependencies = [
  "crc",
+ "critical-section",
  "defmt",
  "embassy-sync",
  "embedded-io-adapters",

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -15,7 +15,9 @@ cargo fmt -- --check
 
 # Check everything first
 cargo check --all-targets --locked
-cargo clippy --all-targets
+if [ -z "NO_CLIPPY" ]; then
+    cargo clippy --all-targets
+fi
 
 # stable, std
 cargo build --release

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 categories = ["network-programming", "embedded", "hardware-support", "no-std"]
-rust-version = "1.82"
+rust-version = "1.85"
 
 [dependencies]
 crc = { workspace = true }

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -23,8 +23,10 @@ uuid = { workspace = true }
 critical-section = { version = "1.2.0", features = ["std"] }
 embedded-io-adapters = { workspace = true }
 env_logger =  { workspace = true }
+futures = "0.3"
 proptest = { workspace = true }
 smol = { workspace = true }
+
 
 [features]
 default = ["log"]

--- a/mctp-estack/Cargo.toml
+++ b/mctp-estack/Cargo.toml
@@ -20,6 +20,7 @@ smbus-pec = { version = "1.0", features = ["lookup-table"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
+critical-section = { version = "1.2.0", features = ["std"] }
 embedded-io-adapters = { workspace = true }
 env_logger =  { workspace = true }
 proptest = { workspace = true }

--- a/mctp-estack/src/fragment.rs
+++ b/mctp-estack/src/fragment.rs
@@ -109,7 +109,6 @@ impl Fragmenter {
         // Reserve header space, the remaining buffer keeps being
         // updated in `rest`
         let max_total = out.len().min(self.mtu);
-        // let out = &mut out[..max_total];
         let (h, mut rest) = out[..max_total].split_at_mut(MctpHeader::LEN);
 
         // Append type byte

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -769,7 +769,8 @@ impl EventStamp {
             return None;
         };
 
-        timeout.checked_sub(elapsed)
+        // zero time_remaining should return None.
+        (elapsed < timeout).then(|| timeout - elapsed)
     }
 }
 

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -677,7 +677,7 @@ pub struct MctpMessage<'a> {
     retain: bool,
 }
 
-impl<'a> MctpMessage<'a> {
+impl MctpMessage<'_> {
     /// Retrieve the message's cookie.
     ///
     /// For response messages with `tag.is_owner() == false` this will be
@@ -704,7 +704,7 @@ impl<'a> MctpMessage<'a> {
     }
 }
 
-impl<'a> Drop for MctpMessage<'a> {
+impl Drop for MctpMessage<'_> {
     fn drop(&mut self) {
         if !self.retain {
             self.reassembler.set_unused()

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -26,7 +26,9 @@
 //! These can be configured at build time, see [`config`]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![forbid(unsafe_code)]
+// Temporarily relaxed for zerocopy_channel vendored code.
+#![deny(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![allow(clippy::int_plus_one)]
 #![allow(clippy::too_many_arguments)]
 // defmt does not currently allow inline format arguments, so we don't want
@@ -64,6 +66,10 @@ pub mod usb;
 #[macro_use]
 mod util;
 mod proto;
+
+#[rustfmt::skip]
+#[allow(clippy::needless_lifetimes)]
+mod zerocopy_channel;
 
 use fragment::{Fragmenter, SendOutput};
 use reassemble::Reassembler;

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -236,6 +236,13 @@ impl Stack {
         }
     }
 
+    /// Return the current internal timestamp.
+    ///
+    /// This is the time last set with `update_clock()`.
+    pub fn now(&self) -> u64 {
+        self.now.clock
+    }
+
     /// Updates timeouts and returns the next timeout in milliseconds
     ///
     /// Must be called regularly to update the current clock value.

--- a/mctp-estack/src/lib.rs
+++ b/mctp-estack/src/lib.rs
@@ -119,6 +119,8 @@ pub mod config {
     /// Customise with `MCTP_ESTACK_NUM_RECEIVE` environment variable.
     /// Number of outstanding waiting responses, default 64
     pub const NUM_RECEIVE: usize = get_build_var!("MCTP_ESTACK_NUM_RECEIVE", 4);
+
+    /// Maximum number of incoming flows, default 64.
     ///
     /// After a message is sent with Tag Owner (TO) bit set, the stack will accept
     /// response messages with the same tag and TO _unset_. `FLOWS` defines
@@ -136,6 +138,20 @@ pub mod config {
     pub const MAX_MTU: usize = get_build_var!("MCTP_ESTACK_MAX_MTU", 255);
     const _: () =
         assert!(MAX_MTU >= crate::MctpHeader::LEN + 1, "MAX_MTU too small");
+
+    /// Per-port transmit queue length, default 4.
+    ///
+    /// This applies to [`Router`](crate::Router).
+    /// Each port will use `PORT_TXQUEUE` * `MAX_MTU` buffer space.
+    ///
+    /// Customise with `MCTP_ESTACK_PORT_TXQUEUE` environment variable.
+    pub const PORT_TXQUEUE: usize =
+        get_build_var!("MCTP_ESTACK_PORT_TXQUEUE", 4);
+
+    /// Maximum number of ports for [`Router`](crate::Router), default 1.
+    ///
+    /// Customise with `MCTP_ESTACK_MAX_PORTS` environment variable.
+    pub const MAX_PORTS: usize = get_build_var!("MCTP_ESTACK_MAX_PORTS", 2);
 }
 
 #[derive(Debug)]

--- a/mctp-estack/src/router.rs
+++ b/mctp-estack/src/router.rs
@@ -773,7 +773,14 @@ impl<'r> Router<'r> {
     }
 }
 
+impl core::fmt::Debug for Router<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Router").finish_non_exhaustive()
+    }
+}
+
 /// A request channel.
+#[derive(Debug)]
 pub struct RouterAsyncReqChannel<'g, 'r> {
     /// Destination EID
     eid: Eid,
@@ -942,6 +949,7 @@ impl mctp::AsyncReqChannel for RouterAsyncReqChannel<'_, '_> {
 /// A response channel.
 ///
 /// Returned by [`RouterAsyncListener::recv`](mctp::AsyncListener::recv).
+#[derive(Debug)]
 pub struct RouterAsyncRespChannel<'g, 'r> {
     eid: Eid,
     tv: TagValue,
@@ -990,6 +998,7 @@ impl<'g, 'r> mctp::AsyncRespChannel for RouterAsyncRespChannel<'g, 'r> {
 /// A listener.
 ///
 /// Created with [`Router::listener()`](Router::listener).
+#[derive(Debug)]
 pub struct RouterAsyncListener<'g, 'r> {
     router: &'g Router<'r>,
     cookie: AppCookie,

--- a/mctp-estack/src/router.rs
+++ b/mctp-estack/src/router.rs
@@ -423,13 +423,19 @@ pub struct RouterInner<'r> {
 impl<'r> Router<'r> {
     /// Create a new Router.
     ///
-    /// The EID of the provided `stack` is used to match local destination packets.
-    ///
-    /// `ports` is a list of transport interfaces for the router. The indices
-    /// of the `ports`  slice are used as `PortId` identifiers.
+    /// `own_eid` is the EID that will respond locally to messages, and
+    /// is used as a source address.
     ///
     /// `lookup` callbacks define the routing table for outbound packets.
-    pub fn new(stack: Stack, lookup: &'r dyn PortLookup) -> Self {
+    ///
+    /// `now_millis` is the current timestamp, as would be provided to
+    /// [`update_time`](Self::update_time).
+    pub fn new(
+        own_eid: Eid,
+        lookup: &'r dyn PortLookup,
+        now_millis: u64,
+    ) -> Self {
+        let stack = Stack::new(own_eid, now_millis);
         let inner = RouterInner { stack, lookup };
 
         let app_listeners = BlockingMutex::new(RefCell::new(Vec::new()));

--- a/mctp-estack/src/router.rs
+++ b/mctp-estack/src/router.rs
@@ -20,8 +20,8 @@ use crate::{
 };
 use mctp::{Eid, Error, MsgIC, MsgType, Result, Tag, TagValue};
 
+use crate::zerocopy_channel::{Channel, Receiver, Sender};
 use embassy_sync::waitqueue::WakerRegistration;
-use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 
 use heapless::{Entry, FnvIndexMap, Vec};
 

--- a/mctp-estack/src/router.rs
+++ b/mctp-estack/src/router.rs
@@ -735,9 +735,7 @@ impl<'r> Router<'r> {
         let Tag::Owned(tv) = tag else { unreachable!() };
         let mut inner = self.inner.lock().await;
 
-        if let Err(e) = inner.stack.cancel_flow(eid, tv) {
-            warn!("flow cancel failed {}", e);
-        }
+        inner.stack.cancel_flow(eid, tv);
     }
 
     /// Create a `AsyncReqChannel` instance.

--- a/mctp-estack/src/zerocopy_channel.rs
+++ b/mctp-estack/src/zerocopy_channel.rs
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/* Copyright (c) Embassy project contributors */
+
+/* This is temporarily copied from embassy-sync, with modifications to add 
+ * FixedChannel and Channel sender()/receiver(). It will be replaced
+ * once upstream.
+ * https://github.com/embassy-rs/embassy/pull/4299
+ *
+ * Based on upstream 6186d111a5c150946ee5b7e9e68d987a38c1a463
+ * plus 
+ * 0ab37d4dbdcf ("embassy-sync: zerocopy Channel sender()/receiver()")
+ * e9db18bf5051 ("embassy-sync: Add zerocopy_channel::FixedChannel")
+ */
+
+#![allow(unsafe_code)]
+#![allow(dead_code)]
+
+//! A zero-copy queue for sending values between asynchronous tasks.
+//!
+//! It can be used concurrently by a producer (sender) and a
+//! consumer (receiver), i.e. it is an  "SPSC channel".
+//!
+//! This queue takes a Mutex type so that various
+//! targets can be attained. For example, a ThreadModeMutex can be used
+//! for single-core Cortex-M targets where messages are only passed
+//! between tasks running in thread mode. Similarly, a CriticalSectionMutex
+//! can also be used for single-core targets where messages are to be
+//! passed from exception mode e.g. out of an interrupt handler.
+//!
+//! This module provides a bounded channel that has a limit on the number of
+//! messages that it can store, and if this limit is reached, trying to send
+//! another message will result in an error being returned.
+
+use core::cell::{RefCell, UnsafeCell};
+use core::future::{poll_fn, Future};
+use core::marker::PhantomData;
+use core::task::{Context, Poll};
+
+use embassy_sync::blocking_mutex::raw::RawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::waitqueue::WakerRegistration;
+
+struct ChannelInner<M: RawMutex, T> {
+    state: Mutex<M, RefCell<State<T>>>,
+}
+
+impl<M: RawMutex, T> ChannelInner<M, T> {
+    /// Initialize a new [`Channel`].
+    ///
+    /// The provided buffer will be used and reused by the channel's logic, and thus dictates the
+    /// channel's capacity.
+    fn new(len: usize, buf: BufferPtr<T>) -> Self {
+        assert!(len != 0);
+
+        Self {
+            state: Mutex::new(RefCell::new(State {
+                capacity: len,
+                buf,
+                front: 0,
+                back: 0,
+                full: false,
+                send_waker: WakerRegistration::new(),
+                receive_waker: WakerRegistration::new(),
+                have_sender: false,
+                have_receiver: false,
+            })),
+        }
+    }
+
+    /// Creates a [`Sender`] and [`Receiver`] from an existing channel.
+    ///
+    /// Further Senders and Receivers can be created through [`Sender::borrow`] and
+    /// [`Receiver::borrow`] respectively.
+    pub fn split(&mut self) -> (Sender<'_, M, T>, Receiver<'_, M, T>) {
+        let mut s = self.state.get_mut().borrow_mut();
+        // We can unconditionally add a sender/receiver since
+        // split() takes a mut reference, so there must be no
+        // existing Sender or Receiver.
+        s.add_sender();
+        s.add_receiver();
+        drop(s);
+        (Sender { channel: self }, Receiver { channel: self })
+    }
+
+    /// Create a [`Receiver`] from an existing channel.
+    ///
+    /// Only one `Receiver` may be borrowed.
+    pub fn receiver(&self) -> Option<Receiver<'_, M, T>> {
+        self.state
+            .lock(|s| s.borrow_mut().add_receiver())
+            .then(|| Receiver { channel: self })
+    }
+
+    /// Create a [`Sender`] from an existing channel.
+    ///
+    /// Only one `Sender` may be borrowed.
+    pub fn sender(&self) -> Option<Sender<'_, M, T>> {
+        self.state
+            .lock(|s| s.borrow_mut().add_sender())
+            .then(|| Sender { channel: self })
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&mut self) {
+        self.state.get_mut().borrow_mut().clear();
+    }
+
+    /// Returns the number of elements currently in the channel.
+    pub fn len(&self) -> usize {
+        self.state.lock(|s| s.borrow().len())
+    }
+
+    /// Returns whether the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        self.state.lock(|s| s.borrow().is_empty())
+    }
+
+    /// Returns whether the channel is full.
+    pub fn is_full(&self) -> bool {
+        self.state.lock(|s| s.borrow().is_full())
+    }
+}
+
+#[repr(transparent)]
+struct BufferPtr<T>(*mut T);
+
+impl<T> BufferPtr<T> {
+    unsafe fn add(&self, count: usize) -> *mut T {
+        self.0.add(count)
+    }
+}
+
+unsafe impl<T> Send for BufferPtr<T> {}
+unsafe impl<T> Sync for BufferPtr<T> {}
+
+/// A bounded zero-copy channel for communicating between asynchronous tasks
+/// with backpressure. Uses a borrowed buffer.
+///
+/// The channel will buffer up to the provided number of messages.  Once the
+/// buffer is full, attempts to `send` new messages will wait until a message is
+/// received from the channel.
+///
+/// All data sent will become available in the same order as it was sent.
+///
+/// The channel requires a buffer of recyclable elements.  Writing to the channel is done through
+/// an `&mut T`.
+pub struct Channel<'a, M: RawMutex, T> {
+    channel: ChannelInner<M, T>,
+    phantom: PhantomData<&'a mut T>,
+}
+
+impl<'a, M: RawMutex, T> Channel<'a, M, T> {
+    /// Initialize a new [`Channel`].
+    ///
+    /// The provided buffer will be used and reused by the channel's logic, and thus dictates the
+    /// channel's capacity.
+    pub fn new(buf: &'a mut [T]) -> Self {
+        Self {
+            channel: ChannelInner::new(buf.len(), BufferPtr(buf.as_mut_ptr())),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Creates a [`Sender`] and [`Receiver`] from an existing channel.
+    ///
+    /// Further Senders and Receivers can be created through [`Sender::borrow`] and
+    /// [`Receiver::borrow`] respectively.
+    pub fn split(&mut self) -> (Sender<'_, M, T>, Receiver<'_, M, T>) {
+        self.channel.split()
+    }
+
+    /// Create a [`Receiver`] from an existing channel.
+    ///
+    /// Only one `Receiver` may be borrowed.
+    pub fn receiver(&self) -> Option<Receiver<'_, M, T>> {
+        self.channel.receiver()
+    }
+
+    /// Create a [`Sender`] from an existing channel.
+    ///
+    /// Only one `Sender` may be borrowed.
+    pub fn sender(&self) -> Option<Sender<'_, M, T>> {
+        self.channel.sender()
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&mut self) {
+        self.channel.clear()
+    }
+
+    /// Returns the number of elements currently in the channel.
+    pub fn len(&self) -> usize {
+        self.channel.len()
+    }
+
+    /// Returns whether the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.is_empty()
+    }
+
+    /// Returns whether the channel is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.is_full()
+    }
+}
+
+/// A bounded zero-copy channel for communicating between asynchronous tasks
+/// with backpressure. Uses a local buffer.
+///
+/// The channel will buffer up to the provided number of messages.  Once the
+/// buffer is full, attempts to `send` new messages will wait until a message is
+/// received from the channel.
+///
+/// All data sent will become available in the same order as it was sent.
+///
+/// The channel uses an internal buffer of `N` elements, they must implement
+/// `Default` for initial placeholders.
+// TODO could make buf MaybeUninit then write through that?
+pub struct FixedChannel<M: RawMutex, T, const N: usize> {
+    channel: ChannelInner<M, T>,
+    // Storage must not be accessed directly, only in update_ptr()
+    storage: Storage<T, N>,
+}
+
+// Storage is always accessed locked by channel
+//
+// The storage is safe from aliasing because only a single Sender or Reciver
+// can access any array element at a time.
+//
+// It is safe to implement Sync and Safe because any Sender or Receiver will
+// borrow from the ChannelInner (having the same lifetime as storage), and storage
+// is only manipulated through Sender and Receiver.
+#[repr(transparent)]
+struct Storage<T, const N: usize>(UnsafeCell<[T; N]>);
+unsafe impl<T, const N: usize> Sync for Storage<T, N> {}
+unsafe impl<T, const N: usize> Send for Storage<T, N> {}
+
+impl<M: RawMutex, T: Default, const N: usize> FixedChannel<M, T, N> {
+    /// Initialize a new [`FixedChannel`].
+    pub fn new() -> Self {
+        // Initial pointer is null, set before use with update_ptr()
+        let channel = ChannelInner::new(N, BufferPtr(core::ptr::null_mut()));
+        Self {
+            channel,
+            storage: Storage(UnsafeCell::new([(); N].map(|_| Default::default()))),
+        }
+    }
+}
+
+impl<M: RawMutex, T: Default, const N: usize> Default for FixedChannel<M, T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<M: RawMutex, T: Clone, const N: usize> FixedChannel<M, T, N> {
+    /// Initialize a new [`FixedChannel`].
+    ///
+    /// This take an initial buffer value to clone.
+    pub fn new_cloned(initial: &T) -> Self {
+        // Initial pointer is null, set before use with update_ptr()
+        let channel = ChannelInner::new(N, BufferPtr(core::ptr::null_mut()));
+        Self {
+            channel,
+            storage: Storage(UnsafeCell::new([(); N].map(|_| initial.clone()))),
+        }
+    }
+}
+
+impl<M: RawMutex, T, const N: usize> FixedChannel<M, T, N> {
+    /// Update the buf pointer.
+    ///
+    /// This must occur before each Sender/Receiver borrow to ensure it's not stale.
+    /// The lifetime of Sender/Receiver guarantees that it won't go stale
+    /// while one of them is active, and buf is only used by a Sender or Receiver.
+    fn update_ptr(&self) {
+        self.channel.state.lock(|s| {
+            // Point to first storage array element
+            s.borrow_mut().buf = BufferPtr(self.storage.0.get() as *mut T);
+        });
+    }
+
+    /// Creates a [`Sender`] and [`Receiver`] from an existing channel.
+    ///
+    /// Further Senders and Receivers can be created through [`Sender::borrow`] and
+    /// [`Receiver::borrow`] respectively.
+    pub fn split(&mut self) -> (Sender<'_, M, T>, Receiver<'_, M, T>) {
+        self.update_ptr();
+        self.channel.split()
+    }
+
+    /// Create a [`Receiver`] from an existing channel.
+    ///
+    /// Only one `Receiver` may be borrowed.
+    pub fn receiver(&self) -> Option<Receiver<'_, M, T>> {
+        self.update_ptr();
+        self.channel.receiver()
+    }
+
+    /// Create a [`Sender`] from an existing channel.
+    ///
+    /// Only one `Sender` may be borrowed.
+    pub fn sender(&self) -> Option<Sender<'_, M, T>> {
+        self.update_ptr();
+        self.channel.sender()
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&mut self) {
+        self.channel.clear()
+    }
+
+    /// Returns the number of elements currently in the channel.
+    pub fn len(&self) -> usize {
+        self.channel.len()
+    }
+
+    /// Returns whether the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.is_empty()
+    }
+
+    /// Returns whether the channel is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.is_full()
+    }
+}
+
+/// Send-only access to a [`Channel`] or [`FixedChannel`].
+pub struct Sender<'a, M: RawMutex, T> {
+    channel: &'a ChannelInner<M, T>,
+}
+
+impl<'a, M: RawMutex, T> Sender<'a, M, T> {
+    /// Creates one further [`Sender`] over the same channel.
+    pub fn borrow(&mut self) -> Sender<'_, M, T> {
+        Sender { channel: self.channel }
+    }
+
+    /// Attempts to send a value over the channel.
+    pub fn try_send(&mut self) -> Option<&mut T> {
+        self.channel.state.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            match s.push_index() {
+                Some(i) => Some(unsafe { &mut *s.buf.add(i) }),
+                None => None,
+            }
+        })
+    }
+
+    /// Attempts to send a value over the channel.
+    pub fn poll_send(&mut self, cx: &mut Context) -> Poll<&mut T> {
+        self.channel.state.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            match s.push_index() {
+                Some(i) => Poll::Ready(unsafe { &mut *s.buf.add(i) }),
+                None => {
+                    s.receive_waker.register(cx.waker());
+                    Poll::Pending
+                }
+            }
+        })
+    }
+
+    /// Asynchronously send a value over the channel.
+    pub fn send(&mut self) -> impl Future<Output = &mut T> {
+        poll_fn(|cx| {
+            self.channel.state.lock(|s| {
+                let s = &mut *s.borrow_mut();
+                match s.push_index() {
+                    Some(i) => {
+                        let r = unsafe { &mut *s.buf.add(i) };
+                        Poll::Ready(r)
+                    }
+                    None => {
+                        s.receive_waker.register(cx.waker());
+                        Poll::Pending
+                    }
+                }
+            })
+        })
+    }
+
+    /// Notify the channel that the sending of the value has been finalized.
+    pub fn send_done(&mut self) {
+        self.channel.state.lock(|s| s.borrow_mut().push_done())
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&mut self) {
+        self.channel.state.lock(|s| {
+            s.borrow_mut().clear();
+        });
+    }
+
+    /// Returns the number of elements currently in the channel.
+    pub fn len(&self) -> usize {
+        self.channel.state.lock(|s| s.borrow().len())
+    }
+
+    /// Returns whether the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.state.lock(|s| s.borrow().is_empty())
+    }
+
+    /// Returns whether the channel is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.state.lock(|s| s.borrow().is_full())
+    }
+}
+
+impl<M: RawMutex, T> Drop for Sender<'_, M, T> {
+    fn drop(&mut self) {
+        self.channel.state.lock(|s| s.borrow_mut().remove_sender())
+    }
+}
+
+/// Receive-only access to a [`Channel`] or [`FixedChannel`].
+pub struct Receiver<'a, M: RawMutex, T> {
+    channel: &'a ChannelInner<M, T>,
+}
+
+impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
+    /// Creates one further [`Receiver`] over the same channel.
+    pub fn borrow(&mut self) -> Receiver<'_, M, T> {
+        Receiver { channel: self.channel }
+    }
+
+    /// Attempts to receive a value over the channel.
+    pub fn try_receive(&mut self) -> Option<&mut T> {
+        self.channel.state.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            match s.pop_index() {
+                Some(i) => Some(unsafe { &mut *s.buf.add(i) }),
+                None => None,
+            }
+        })
+    }
+
+    /// Attempts to asynchronously receive a value over the channel.
+    pub fn poll_receive(&mut self, cx: &mut Context) -> Poll<&mut T> {
+        self.channel.state.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            match s.pop_index() {
+                Some(i) => Poll::Ready(unsafe { &mut *s.buf.add(i) }),
+                None => {
+                    s.send_waker.register(cx.waker());
+                    Poll::Pending
+                }
+            }
+        })
+    }
+
+    /// Asynchronously receive a value over the channel.
+    pub fn receive(&mut self) -> impl Future<Output = &mut T> {
+        poll_fn(|cx| {
+            self.channel.state.lock(|s| {
+                let s = &mut *s.borrow_mut();
+                match s.pop_index() {
+                    Some(i) => {
+                        let r = unsafe { &mut *s.buf.add(i) };
+                        Poll::Ready(r)
+                    }
+                    None => {
+                        s.send_waker.register(cx.waker());
+                        Poll::Pending
+                    }
+                }
+            })
+        })
+    }
+
+    /// Notify the channel that the receiving of the value has been finalized.
+    pub fn receive_done(&mut self) {
+        self.channel.state.lock(|s| s.borrow_mut().pop_done())
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&mut self) {
+        self.channel.state.lock(|s| {
+            s.borrow_mut().clear();
+        });
+    }
+
+    /// Returns the number of elements currently in the channel.
+    pub fn len(&self) -> usize {
+        self.channel.state.lock(|s| s.borrow().len())
+    }
+
+    /// Returns whether the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.state.lock(|s| s.borrow().is_empty())
+    }
+
+    /// Returns whether the channel is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.state.lock(|s| s.borrow().is_full())
+    }
+}
+
+impl<M: RawMutex, T> Drop for Receiver<'_, M, T> {
+    fn drop(&mut self) {
+        self.channel.state.lock(|s| s.borrow_mut().remove_receiver())
+    }
+}
+
+struct State<T> {
+    /// Maximum number of elements the channel can hold.
+    capacity: usize,
+
+    /// Pointer to the channel's buffer.
+    ///
+    /// Will always/only be valid when a Sender or Receiver
+    /// is borrowed.
+    buf: BufferPtr<T>,
+
+    /// Front index. Always 0..=(N-1)
+    front: usize,
+    /// Back index. Always 0..=(N-1).
+    back: usize,
+
+    /// Used to distinguish "empty" and "full" cases when `front == back`.
+    /// May only be `true` if `front == back`, always `false` otherwise.
+    full: bool,
+
+    send_waker: WakerRegistration,
+    receive_waker: WakerRegistration,
+
+    have_receiver: bool,
+    have_sender: bool,
+}
+
+impl<T> State<T> {
+    fn increment(&self, i: usize) -> usize {
+        if i + 1 == self.capacity {
+            0
+        } else {
+            i + 1
+        }
+    }
+
+    fn clear(&mut self) {
+        if self.full {
+            self.receive_waker.wake();
+        }
+        self.front = 0;
+        self.back = 0;
+        self.full = false;
+    }
+
+    fn len(&self) -> usize {
+        if !self.full {
+            if self.back >= self.front {
+                self.back - self.front
+            } else {
+                self.capacity + self.back - self.front
+            }
+        } else {
+            self.capacity
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        self.full
+    }
+
+    fn is_empty(&self) -> bool {
+        self.front == self.back && !self.full
+    }
+
+    fn push_index(&mut self) -> Option<usize> {
+        match self.is_full() {
+            true => None,
+            false => Some(self.back),
+        }
+    }
+
+    fn push_done(&mut self) {
+        assert!(!self.is_full());
+        self.back = self.increment(self.back);
+        if self.back == self.front {
+            self.full = true;
+        }
+        self.send_waker.wake();
+    }
+
+    fn pop_index(&mut self) -> Option<usize> {
+        match self.is_empty() {
+            true => None,
+            false => Some(self.front),
+        }
+    }
+
+    fn pop_done(&mut self) {
+        assert!(!self.is_empty());
+        self.front = self.increment(self.front);
+        self.full = false;
+        self.receive_waker.wake();
+    }
+
+    // Returns true if a sender was added, false if one already existed
+    fn add_sender(&mut self) -> bool {
+        !core::mem::replace(&mut self.have_sender, true)
+    }
+
+    fn remove_sender(&mut self) {
+        debug_assert!(self.have_sender);
+        self.have_sender = false;
+    }
+
+    // Returns true if a receiver was added, false if one already existed
+    fn add_receiver(&mut self) -> bool {
+        !core::mem::replace(&mut self.have_receiver, true)
+    }
+
+    fn remove_receiver(&mut self) {
+        debug_assert!(self.have_receiver);
+        self.have_receiver = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
+    extern crate std;
+    use core::ops::{Deref, DerefMut};
+    use std::boxed::Box;
+
+    #[test]
+    fn split() {
+        let mut buf = [0u32; 10];
+        let mut c = Channel::<NoopRawMutex, _>::new(&mut buf);
+
+        let (mut s, mut r) = c.split();
+
+        *s.try_send().unwrap() = 4;
+        s.send_done();
+
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 4);
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 4);
+        r.receive_done();
+        let b = r.try_receive();
+        assert!(b.is_none());
+    }
+
+    #[test]
+    fn sender_receiver() {
+        let mut buf = [0u32; 10];
+        let c = Channel::<NoopRawMutex, _>::new(&mut buf);
+
+        let mut s = c.sender().unwrap();
+        assert!(c.sender().is_none(), "can't borrow again");
+
+        *s.try_send().unwrap() = 4;
+        s.send_done();
+        drop(s);
+
+        // borrow again
+        let mut s = c.sender().unwrap();
+        *s.try_send().unwrap() = 5;
+        s.send_done();
+
+        let mut r = c.receiver().unwrap();
+        assert!(c.receiver().is_none(), "can't borrow again");
+
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 4);
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 4);
+        r.receive_done();
+
+        drop(r);
+        // borrow again
+        let mut r = c.receiver().unwrap();
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 5);
+        r.receive_done();
+        let b = r.try_receive();
+        assert!(b.is_none());
+    }
+
+    #[test]
+    fn fixed() {
+        let c = FixedChannel::<NoopRawMutex, _, 2>::new();
+
+        let mut s = c.sender().unwrap();
+        assert!(c.sender().is_none(), "can't borrow again");
+        assert!(s.is_empty());
+
+        *s.try_send().unwrap() = 4;
+        assert!(s.is_empty());
+        s.send_done();
+        assert!(!s.is_empty());
+        drop(s);
+
+        let mut s = c.sender().unwrap();
+        *s.try_send().unwrap() = 5;
+        assert!(!s.is_full());
+        s.send_done();
+        assert!(s.try_send().is_none(), "queue is full");
+        assert!(s.is_full());
+
+        let mut r = c.receiver().unwrap();
+        assert!(c.receiver().is_none(), "can't borrow again");
+
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 4);
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 4);
+        r.receive_done();
+
+        drop(r);
+        let mut r = c.receiver().unwrap();
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 5);
+        assert!(!s.is_empty());
+        r.receive_done();
+        assert!(s.is_empty());
+        let b = r.try_receive();
+        assert!(b.is_none());
+
+        // Later send works
+        *s.try_send().unwrap() = 6;
+        assert!(r.is_empty());
+        s.send_done();
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn fixed_move() {
+        // Check that the buffer pointer updates if moved
+        let c = FixedChannel::<CriticalSectionRawMutex, _, 40>::new_cloned(&123);
+
+        let p1 = &c as *const _;
+        let mut s = c.sender().unwrap();
+        *s.try_send().unwrap() = 99u32;
+        s.send_done();
+        drop(s);
+
+        let mut cbox = Box::new(Some(c));
+        let c = cbox.deref().as_ref().unwrap();
+        let p2 = c as *const _;
+
+        let mut r = c.receiver().unwrap();
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 99);
+        r.receive_done();
+        drop(r);
+
+        let mut cbox = Box::new(cbox.take());
+        let c = cbox.deref_mut().as_mut().unwrap();
+        let p3 = c as *const _;
+
+        let (mut s, mut r) = c.split();
+        *s.try_send().unwrap() = 44;
+        s.send_done();
+        let b = r.try_receive().unwrap();
+        assert_eq!(*b, 44);
+
+        assert!(p1 != p2, "Ensure data moved");
+        assert!(p1 != p3, "Ensure data moved");
+        assert!(p2 != p3, "Ensure data moved");
+    }
+}

--- a/mctp-estack/src/zerocopy_channel.rs
+++ b/mctp-estack/src/zerocopy_channel.rs
@@ -331,7 +331,7 @@ pub struct Sender<'a, M: RawMutex, T> {
     channel: &'a ChannelInner<M, T>,
 }
 
-impl<'a, M: RawMutex, T> Sender<'a, M, T> {
+impl<M: RawMutex, T> Sender<'_, M, T> {
     /// Creates one further [`Sender`] over the same channel.
     pub fn borrow(&mut self) -> Sender<'_, M, T> {
         Sender { channel: self.channel }
@@ -420,7 +420,7 @@ pub struct Receiver<'a, M: RawMutex, T> {
     channel: &'a ChannelInner<M, T>,
 }
 
-impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
+impl<M: RawMutex, T> Receiver<'_, M, T> {
     /// Creates one further [`Receiver`] over the same channel.
     pub fn borrow(&mut self) -> Receiver<'_, M, T> {
         Receiver { channel: self.channel }

--- a/mctp-estack/tests/roundtrip.rs
+++ b/mctp-estack/tests/roundtrip.rs
@@ -1,0 +1,534 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * Copyright (c) 2025 Code Construct
+ */
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+use mctp::{Eid, MsgType};
+
+use mctp::{AsyncListener, AsyncReqChannel, AsyncRespChannel};
+use mctp_estack::config::NUM_RECEIVE;
+use mctp_estack::router::{
+    Port, PortId, PortLookup, PortTop, RouterAsyncReqChannel,
+};
+use mctp_estack::{config, Router};
+
+use futures::{select, FutureExt};
+use std::collections::VecDeque;
+use std::future::Future;
+
+pub mod test_step_executor;
+use test_step_executor::{StepExecutor, SubTaskRunner};
+
+fn start_log() {
+    let _ = env_logger::Builder::new()
+        .filter(None, log::LevelFilter::Trace)
+        .is_test(true)
+        .try_init();
+}
+
+/// Always routes out port 0
+#[derive(Default)]
+struct DefaultRoute;
+
+impl PortLookup for DefaultRoute {
+    fn by_eid(
+        &self,
+        _eid: Eid,
+        _src_port: Option<PortId>,
+    ) -> (Option<PortId>, Option<usize>) {
+        (Some(PortId(0)), None)
+    }
+}
+
+const DEFAULT_LOOKUP: DefaultRoute = DefaultRoute;
+
+/// Formats hex plus printable ascii
+struct HexFmt<'a>(&'a [u8]);
+impl core::fmt::Debug for HexFmt<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:02x?}  ", self.0)?;
+        for c in self.0 {
+            if c.is_ascii() && !c.is_ascii_control() {
+                write!(f, "{}", char::from(*c))?;
+            } else {
+                write!(f, ".")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn receive_loop(
+    name: &str,
+    router: &Router<'_>,
+    p: PortId,
+    mut port: Port<'_>,
+) -> ! {
+    loop {
+        let (pkt, _eid) = port.outbound().await;
+        trace!("rx {name} {:?}", HexFmt(pkt));
+        router.inbound(pkt, p).await;
+        port.outbound_done();
+    }
+}
+
+/// Run a loop forwarding packets between routera and routerb.
+///
+/// The `test` Future runs to completion.
+async fn router_loop(routera: &Router<'_>, routerb: &Router<'_>) -> ! {
+    let port1 = routera.port(PortId(0)).unwrap();
+    let port2 = routerb.port(PortId(0)).unwrap();
+    let a = receive_loop("a", routerb, port1.id(), port1);
+    let b = receive_loop("b", routera, port2.id(), port2);
+
+    select! {
+        _ = a.fuse() => unreachable!(),
+        _ = b.fuse() => unreachable!(),
+    }
+}
+
+fn run<F, R>(routera: &Router<'_>, routerb: &Router<'_>, test: F) -> R
+where
+    F: Future<Output = R>,
+{
+    let pktloop = router_loop(routera, routerb);
+    smol::block_on(async {
+        select! {
+            res = test.fuse() => {
+                info!("Finished");
+                res
+            }
+            _ = pktloop.fuse() => unreachable!(),
+        }
+    })
+}
+
+fn routers<'r>(
+    tops: &'r mut [PortTop],
+    lookup1: &'r dyn PortLookup,
+    lookup2: &'r dyn PortLookup,
+) -> (Router<'r>, Router<'r>) {
+    start_log();
+    let mut p = tops.iter_mut();
+    let mut routera = Router::new(Eid(10), lookup1, 0);
+    let mut routerb = Router::new(Eid(20), lookup2, 0);
+    routera.add_port(p.next().unwrap()).unwrap();
+    routerb.add_port(p.next().unwrap()).unwrap();
+    (routera, routerb)
+}
+
+/// Simple request/response
+#[test]
+fn router_requests() {
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    run(&routera, &routerb, async {
+        let typ = MsgType(0x33);
+        let mut buf = [0u8; 1000];
+
+        let mut lista = routera.listener(typ).unwrap();
+
+        let mut reqb = routerb.req(routera.get_eid().await);
+        reqb.send(typ, b"first").await.unwrap();
+        reqb.send(typ, b"second").await.unwrap();
+
+        // check first request
+        let (_t, _ic, payload, _resp) = lista.recv(&mut buf).await.unwrap();
+        assert_eq!(payload, b"first");
+
+        // respond only to the second request
+        let (_t, _ic, payload, mut resp) = lista.recv(&mut buf).await.unwrap();
+        assert_eq!(payload, b"second");
+        resp.send(b"reply2").await.unwrap();
+        let (_t, _ic, payload) = reqb.recv(&mut buf).await.unwrap();
+        assert_eq!(payload, b"reply2");
+    });
+}
+
+/// Test a requester with tag_noexpire()
+#[test]
+fn router_noexpire() {
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    run(&routera, &routerb, async {
+        let typ = MsgType(0x33);
+        let mut buf = [0u8; 1000];
+
+        let mut lista = routera.listener(typ).unwrap();
+        let mut reqb = routerb.req(routera.get_eid().await);
+        reqb.tag_noexpire().unwrap();
+
+        let mut counter = 0;
+
+        // Greater iteration count than tag limit.
+        for _ in 0..20 {
+            // Request
+            for s in 0..config::NUM_RECEIVE {
+                let msg = format!("req-{}", counter + s).into_bytes();
+                reqb.send(typ, &msg).await.unwrap();
+            }
+
+            // Listener receive the request
+            let mut resps = VecDeque::new();
+            for s in 0..config::NUM_RECEIVE {
+                let msg = format!("req-{}", counter + s).into_bytes();
+                let (_t, _ic, payload, resp) =
+                    lista.recv(&mut buf).await.unwrap();
+                assert_eq!(payload, msg);
+                resps.push_front(resp);
+            }
+
+            // Listener respond
+            for s in 0..config::NUM_RECEIVE {
+                let msg = format!("resp-{}", counter + s).into_bytes();
+                let mut resp = resps.pop_front().unwrap();
+                resp.send(&msg).await.unwrap();
+            }
+
+            // Check the response
+            for s in 0..config::NUM_RECEIVE {
+                let msg = format!("resp-{}", counter + s).into_bytes();
+                let (_t, _ic, payload) = reqb.recv(&mut buf).await.unwrap();
+                assert_eq!(payload, msg);
+            }
+            counter += config::NUM_RECEIVE;
+        }
+    });
+}
+
+#[test]
+fn router_listener_timeout() {
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    let mut ex = StepExecutor::default();
+    ex.add(router_loop(&routera, &routerb));
+
+    let test = async |sub: SubTaskRunner| {
+        let mut now = 0;
+        let typ = MsgType(0x33);
+        let mut buf = [0u8; 1000];
+
+        let mut lista = routera.listener(typ).unwrap();
+        lista.set_timeout(Some(1000));
+
+        let mut reqb = routerb.req(routera.get_eid().await);
+
+        // timed out case
+        let recv_task =
+            sub.start_until_idle(lista.recv(&mut buf)).await.unwrap();
+
+        // Send the message after the recv timeout has elapsed.
+        now += 1000;
+        routera.update_time(now).await.unwrap();
+        reqb.send(typ, b"late").await.unwrap();
+
+        let r = recv_task.await;
+        assert!(matches!(r, Err(mctp::Error::TimedOut)));
+
+        // subsequent recv on the listener receives it
+        let (_typ, _ic, payload, _resp) = lista.recv(&mut buf).await.unwrap();
+        assert_eq!(payload, b"late");
+
+        // not timed out case
+        let recv_task =
+            sub.start_until_idle(lista.recv(&mut buf)).await.unwrap();
+
+        // Send the message before the recv timeout has elapsed.
+        now += 999;
+        routera.update_time(now).await.unwrap();
+        reqb.send(typ, b"in the nick of time").await.unwrap();
+        let (_typ, _ic, payload, _resp) = recv_task.await.unwrap();
+        assert_eq!(payload, b"in the nick of time");
+    };
+    ex.add(test(ex.sub_runner()));
+    ex.until_idle();
+}
+
+#[test]
+fn router_req_timeout() {
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    let mut ex = StepExecutor::default();
+    ex.add(router_loop(&routera, &routerb));
+
+    let test = async |sub: SubTaskRunner| {
+        let mut now = 0;
+        let typ = MsgType(0x33);
+        let mut bufa = [0u8; 1000];
+        let mut bufb = [0u8; 1000];
+
+        let mut lista = routera.listener(typ).unwrap();
+
+        let mut reqb = routerb.req(routera.get_eid().await);
+        reqb.set_timeout(Some(1000));
+
+        info!("timed out case");
+        reqb.send(typ, b"req").await.unwrap();
+        let (_typ, _ic, _payload, mut resp) =
+            lista.recv(&mut bufa).await.unwrap();
+
+        let recv_task =
+            sub.start_until_idle(reqb.recv(&mut bufb)).await.unwrap();
+
+        now += 1000;
+        routerb.update_time(now).await.unwrap();
+        trace!("new now {now}");
+        let r = recv_task.await;
+        assert!(
+            matches!(r, Err(mctp::Error::TimedOut)),
+            "no response was sent"
+        );
+
+        info!("subsequent recv gets it");
+        resp.send(b"later").await.unwrap();
+        let (_typ, _ic, payload) = reqb.recv(&mut bufb).await.unwrap();
+        assert_eq!(payload, b"later");
+
+        info!("late message");
+        reqb.send(typ, b"req").await.unwrap();
+        let (_typ, _ic, _payload, mut resp) =
+            lista.recv(&mut bufa).await.unwrap();
+
+        let recv_task =
+            sub.start_until_idle(reqb.recv(&mut bufb)).await.unwrap();
+
+        now += 1000;
+        routerb.update_time(now).await.unwrap();
+
+        // Send the message after the recv timeout has elapsed.
+        resp.send(b"late").await.unwrap();
+
+        // Ensure the stack receives it it before recv() runs.
+        sub.wait_idle().await;
+
+        let (_typ, _ic, payload) = recv_task.await.unwrap();
+        assert_eq!(payload, b"late");
+
+        info!("A new cycle succeeds within timeout.");
+        reqb.send(typ, b"req").await.unwrap();
+        let (_typ, _ic, _payload, mut resp) =
+            lista.recv(&mut bufa).await.unwrap();
+
+        let recv_task =
+            sub.start_until_idle(reqb.recv(&mut bufb)).await.unwrap();
+
+        // Before elapsed
+        now += 999;
+        routerb.update_time(now).await.unwrap();
+        resp.send(b"made it").await.unwrap();
+
+        let (_typ, _ic, payload) = recv_task.await.unwrap();
+        assert_eq!(payload, b"made it");
+    };
+    ex.add(test(ex.sub_runner()));
+    ex.until_idle();
+}
+
+#[test]
+fn router_reassembly_timeout() {
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    let mut ex = StepExecutor::default();
+    ex.add(router_loop(&routera, &routerb));
+
+    let test = async |sub: SubTaskRunner| {
+        let mut now = 0;
+        let typ = MsgType(0x33);
+        let mut bufa = [0u8; 1000];
+        let mut bufb = [0u8; 1000];
+
+        // 3000 is within the timeout, 8000 is past it.
+        for delay in [3000, 8000] {
+            let mut lista = routera.listener(typ).unwrap();
+
+            // B -> A
+            let mut reqb = routerb.req(routera.get_eid().await);
+            reqb.send(typ, b"test").await.unwrap();
+            let (_typ, _ic, _payload, mut resp) =
+                lista.recv(&mut bufa).await.unwrap();
+
+            now += delay + 100;
+            routerb.update_time(now).await.unwrap();
+
+            sub.wait_idle().await;
+            // A -> B
+            resp.send(b"response").await.unwrap();
+
+            let r = reqb.recv(&mut bufb).await;
+            warn!("delay {delay} r {r:?}");
+            // REASSEMBLY_EXPIRY_TIMEOUT
+            if delay > 6000 {
+                assert!(
+                    matches!(r, Err(mctp::Error::TimedOut)),
+                    "packet shouldn't be received"
+                );
+            } else {
+                assert!(r.is_ok())
+            }
+        }
+    };
+    ex.add(test(ex.sub_runner()));
+    ex.until_idle();
+}
+
+// Tests that retain()ed messages don't expire.
+#[test]
+fn router_retain_timeout() {
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    let mut ex = StepExecutor::default();
+    ex.add(router_loop(&routera, &routerb));
+
+    let test = async |sub: SubTaskRunner| {
+        let mut now = 0;
+        let typ = MsgType(0x33);
+        let mut bufa = [0u8; 1000];
+        let mut bufb = [0u8; 1000];
+
+        let mut lista = routera.listener(typ).unwrap();
+
+        let mut reqb = routerb.req(routera.get_eid().await);
+        reqb.send(typ, b"req").await.unwrap();
+        let (_typ, _ic, _payload, mut resp) =
+            lista.recv(&mut bufa).await.unwrap();
+
+        resp.send(b"response").await.unwrap();
+
+        sub.wait_idle().await;
+        // routerb should now have retain()ed the received message
+
+        // increment time possibly past reassembly timeout
+        now += 100_000;
+        routerb.update_time(now).await.unwrap();
+
+        let r = reqb.recv(&mut bufb).await;
+        assert!(r.is_ok())
+    };
+    ex.run_to_completion(test(ex.sub_runner())).unwrap();
+}
+
+// Checks that dropping reqchannels when full allows further ones to be created
+#[test]
+fn router_drop_cleanup() {
+    #![allow(clippy::needless_range_loop)]
+    let mut tops = [PortTop::new(), PortTop::new()];
+    let (routera, routerb) =
+        routers(&mut tops, &DEFAULT_LOOKUP, &DEFAULT_LOOKUP);
+
+    let mut ex = StepExecutor::default();
+    ex.add(router_loop(&routera, &routerb));
+
+    let test = async |sub: SubTaskRunner| {
+        let mut now = 0;
+        let typ = MsgType(0x33);
+        let mut bufa = [0u8; 1000];
+        let mut bufb = [0u8; 1000];
+
+        let mut send = async |n: usize| {
+            let mut lista = routera.listener(typ).unwrap();
+            let mut reqb = routerb.req(routera.get_eid().await);
+            reqb.set_timeout(Some(1000));
+            reqb.send(typ, b"req").await.unwrap();
+
+            // Send a response, it will get queued in routerb's Stack reassemblers.
+            let (_typ, _ic, _payload, mut resp) =
+                lista.recv(&mut bufb).await.unwrap();
+            resp.send(&n.to_be_bytes()).await.unwrap();
+            reqb
+        };
+
+        let mut recv = async |req: &mut RouterAsyncReqChannel| {
+            let mut recv_task = sub.start(req.recv(&mut bufa));
+            match recv_task.run_until_idle().await {
+                // Already completed
+                Some(r) => r,
+                None => {
+                    // Run to completion.
+                    // Expire the timeout to avoid hangs
+                    now += 2000;
+                    routerb.update_time(now).await.unwrap();
+                    recv_task.await
+                }
+            }
+            .map(|(_typ, _ic, payload)| payload.to_vec())
+        };
+
+        //// Test running out of receivers. Last ones are dropped.
+        {
+            let mut reqs = Vec::new();
+            // Fill all the reassemblers. N+1 would be adequate, N+3 just to see.
+            for n in 0..config::NUM_RECEIVE + 3 {
+                reqs.push(send(n).await);
+            }
+
+            // Ensure they all reached the reassemblers.
+            sub.wait_idle().await;
+
+            // Test that the last one is dropped
+            for n in 0..config::NUM_RECEIVE + 3 {
+                let res = recv(&mut reqs[n]).await;
+
+                if n < config::NUM_RECEIVE {
+                    assert_eq!(res.unwrap(), &n.to_be_bytes());
+                } else {
+                    // Last message is dropped
+                    assert!(matches!(res, Err(mctp::Error::TimedOut)));
+                }
+            }
+        }
+
+        //// Test running out of receivers, then drop channels to allow more messages.
+        {
+            let mut reqs = Vec::new();
+            let skip = [2, 5];
+            for n in 0..config::NUM_RECEIVE + 3 {
+                let r = send(n).await;
+                if skip.contains(&n) {
+                    // Drop reqs 2 and 5
+                    reqs.push(None);
+                } else {
+                    reqs.push(Some(r));
+                };
+            }
+
+            // Ensure they all reached the reassemblers.
+            sub.wait_idle().await;
+
+            // Test that all the non-dropped ones worked, apart from the last one which was full.
+            for n in 0..config::NUM_RECEIVE + 3 {
+                trace!("recv {n}");
+
+                let Some(req) = &mut reqs[n] else {
+                    assert!(skip.contains(&n));
+                    continue;
+                };
+                assert!(!skip.contains(&n));
+
+                let res = recv(req).await;
+
+                if n == NUM_RECEIVE + 3 - 1 {
+                    // Last message is dropped
+                    assert!(matches!(res, Err(mctp::Error::TimedOut)));
+                } else {
+                    assert_eq!(res.unwrap(), &n.to_be_bytes());
+                }
+            }
+        }
+    };
+    ex.run_to_completion(test(ex.sub_runner())).unwrap();
+}

--- a/mctp-estack/tests/test_step_executor.rs
+++ b/mctp-estack/tests/test_step_executor.rs
@@ -1,0 +1,666 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+/*
+ * Copyright (c) 2025 Code Construct
+ */
+
+//! A specialised executor for testing.
+//!
+//! The `StepExecutor` allows run-until-idle, and also
+//! also ensures that each task runs with a distinct waker.
+//!
+//! Currently this doesn't have a mechanism to run beneath other executors,
+//! which would be required to interface with external IO triggers.
+//! That could be added in future by proxying `wake()` calls to a parent executor.
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+use core::future::poll_fn;
+use futures::FutureExt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::sync::{Arc, Weak};
+use std::task::{Context, Poll, Wake, Waker};
+
+/// A test executor
+///
+/// This allows control of task execution.
+/// The executor is not designed to be efficient.
+#[derive(Debug)]
+pub struct StepExecutor<'a> {
+    /// Futures that run at any time
+    tasks: Vec<(Task<'a>, Arc<Pender>)>,
+
+    /// Futures that only run when requested
+    sub_tasks: SubTaskRunner,
+
+    /// A counter, incremented by any wake in any task or subtask.
+    ///
+    /// Used for pessimistic modification detection. Won't overflow.
+    counter: Arc<AtomicU64>,
+}
+
+impl<'a> StepExecutor<'a> {
+    pub fn new() -> Self {
+        let counter = Arc::new(AtomicU64::new(1));
+        Self {
+            tasks: Vec::new(),
+            sub_tasks: SubTaskRunner {
+                penders: Default::default(),
+                counter: counter.clone(),
+            },
+            counter,
+        }
+    }
+
+    /// Retrieves a `SubTaskRunner`.
+    ///
+    /// That can be used to start subtasks, and wait for idleness.
+    pub fn sub_runner(&self) -> SubTaskRunner {
+        self.sub_tasks.clone()
+    }
+
+    /// Adds a future that will run at any time.
+    ///
+    /// The future will run to completion, with output discarded.
+    pub fn add<F: Future<Output = R> + 'a + Sync + Send, R>(&mut self, f: F) {
+        let task = Task::new(f);
+        let pender = Arc::new(Pender::new(self.counter.clone()));
+        trace!(
+            "Add task {}. New pender {}",
+            self.tasks.len(),
+            pender.debug_id()
+        );
+        self.tasks.push((task, pender));
+    }
+
+    /// Adds a future and runs the executor until the future completes.
+    ///
+    /// Returns an error if the executor went idle before the future completes.
+    ///
+    /// TODO: eventually it might be nice to take an `AsyncFnOnce(SubTaskRunner)`
+    /// argument instead, but at present (Rust 1.89) they can't be expressed as
+    /// `Sync+Send`.
+    pub fn run_to_completion<F, R>(&mut self, f: F) -> Result<(), IterLimit>
+    where
+        F: Future<Output = R> + 'a + Sync + Send,
+    {
+        self.add(f);
+        let (_t, pender) = self.tasks.last().unwrap();
+
+        // Keep running until the task is removed.
+        let pender = Arc::downgrade(pender);
+        self.until_idle();
+        if pender.strong_count() > 0 {
+            trace!("Future didn't complete");
+            Err(IterLimit)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn all_main_idle(&self) -> bool {
+        self.tasks.iter().all(|(_t, p)| !p.is_pending())
+    }
+
+    /// Run the executor until no more forward progress can be made.
+    ///
+    /// It is possible for this to never complete if task(s) are continually
+    /// waking.
+    pub fn until_idle(&mut self) {
+        // A single CPU can't count to u64::MAX
+        self.until_idle_limit_iter(u64::MAX).unwrap()
+    }
+
+    /// Run the executor until all tasks complete
+    pub fn run_all(mut self) {
+        while !self.tasks.is_empty() {
+            self.until_idle();
+        }
+    }
+
+    /// The same as until_idle but with an iteration limit
+    ///
+    /// Can be used when testing for expected infinite loops.
+    /// Note that scheduler order is undefined, so even finite loops
+    /// could possibly run for a very long time.
+    ///
+    /// Returns Ok((()) if idle, Err(IterLimit) on iteration limit hit.
+    pub fn until_idle_limit_iter(
+        &mut self,
+        iters: u64,
+    ) -> Result<(), IterLimit> {
+        '_outer: for _ in 0..iters {
+            trace!("loop top");
+            // Check whether all tasks have completed, prior to looking for
+            // idle waiters.
+            let main_idle = self.all_main_idle();
+
+            let mut sub_idle = true;
+            // Iterate over all the live subtasks to find ones where
+            // another task is waiting for idleness.
+            for p in self
+                .sub_tasks
+                .penders
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|p| p.upgrade())
+            {
+                p.with(|p| {
+                    while let Some(p) = p.subtask_idle_waiters.pop() {
+                        sub_idle = false;
+                        p.wake();
+                    }
+                    p.subtask_idle = main_idle;
+                    // Read the counter after waking idle waiters. Otherwise
+                    // subtask_idle_counter will always be outdated (wake() increments
+                    // the global counter).
+                    //
+                    // There is still the chance that a future wake
+                    // makes the counter outdated before being compared,
+                    // but in that case another 'outer loop will occur and will eventually
+                    // run with a not-outdated counter.
+                    let now = self.counter.load(Ordering::SeqCst);
+                    p.subtask_idle_counter = now;
+                })
+            }
+
+            trace!("main_idle {main_idle:?} sub_idle {sub_idle:?}");
+
+            if main_idle && sub_idle {
+                // Reached quiescent state.
+                return Ok(());
+            }
+
+            // Run tasks, removing completed ones.
+            self.tasks.retain_mut(|(t, pender)| {
+                // Clear pending flag
+                if pender.clear() {
+                    // Poll pending tasks
+                    let w = Waker::from(pender.clone());
+                    let mut cx = Context::from_waker(&w);
+                    if t.fut.poll_unpin(&mut cx).is_ready() {
+                        // Task is done, remove it.
+                        return false;
+                    }
+                }
+                true
+            });
+        }
+        Err(IterLimit)
+    }
+}
+
+impl Default for StepExecutor<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error returned when an iteration limit is reached.
+#[derive(Debug)]
+pub struct IterLimit;
+
+/// Represents the wakeup state of a task.
+///
+/// An `Arc<Pender>` is passed as a "task handle", and is convertible to/from a `Waker`
+/// via `StepExecutor::task_from_waker()`. `PenderHandle` implements hash etc as a newtype.
+#[derive(Debug)]
+struct Pender {
+    inner: Mutex<PenderInner>,
+    counter: Arc<AtomicU64>,
+}
+
+impl Pender {
+    fn new(counter: Arc<AtomicU64>) -> Self {
+        trace!("Pender new, counter {}", counter.load(Ordering::SeqCst));
+        assert_ne!(counter.load(Ordering::SeqCst), 0);
+        let inner = PenderInner {
+            // New tasks are pending to poll at least once.
+            pending: true,
+            subtask_idle_waiters: Vec::new(),
+            subtask_idle: false,
+            subtask_idle_counter: 0,
+        };
+        Self {
+            inner: Mutex::new(inner),
+            counter,
+        }
+    }
+
+    fn debug_id(self: &Arc<Self>) -> String {
+        format!("Pender({:#x?})", Arc::as_ptr(self))
+    }
+
+    fn with<F, R>(&self, mut f: F) -> R
+    where
+        F: FnMut(&mut PenderInner) -> R,
+    {
+        let mut p = self.inner.lock().unwrap();
+        f(&mut p)
+    }
+
+    /// Clears the pending bit, returns the previous value.
+    fn clear(&self) -> bool {
+        self.with(|p| core::mem::replace(&mut p.pending, false))
+    }
+
+    fn is_pending(&self) -> bool {
+        self.with(|p| p.pending)
+    }
+
+    fn read_counter(&self) -> u64 {
+        self.counter.load(Ordering::SeqCst)
+    }
+}
+
+impl Wake for Pender {
+    fn wake(self: Arc<Self>) {
+        trace!("wake {}", self.debug_id());
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        self.with(|p| {
+            p.pending = true;
+            // Wake any parent waiters of a subtask
+            for wt in &p.subtask_idle_waiters {
+                wt.wake_by_ref();
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+struct PenderInner {
+    /// Only set by wake()
+    pending: bool,
+
+    /// For subtasks, a list of other tasks waiting for this to go idle.
+    subtask_idle_waiters: Vec<Waker>,
+
+    /// Set true when idle.
+    ///
+    /// Is set pessemistically. Should be discarded if counter has advanced
+    /// past subtask_idle_counter.
+    subtask_idle: bool,
+
+    /// Counter value when subtask_idle was set, to track staleness.
+    subtask_idle_counter: u64,
+}
+
+/// State shared between `StepExecutor` and tasks.
+#[derive(Clone, Debug)]
+pub struct SubTaskRunner {
+    penders: Arc<Mutex<Vec<Weak<Pender>>>>,
+    counter: Arc<AtomicU64>,
+}
+
+impl SubTaskRunner {
+    /// Starts a subtask.
+    pub fn start<'a, F: Future<Output = R> + 'a + Sync + Send, R>(
+        &self,
+        f: F,
+    ) -> SubTask<'a, R> {
+        trace!("Start, counter {}", self.counter.load(Ordering::SeqCst));
+        let st = SubTask::new(f, self.counter.clone());
+        self.penders
+            .lock()
+            .unwrap()
+            .push(Arc::downgrade(&st.pender));
+        st
+    }
+
+    /// Starts a subtask and runs it until all tasks are idle.
+    ///
+    /// Returns `Ok` if it goes idle, or `Err` with the result if it completes early.
+    pub async fn start_until_idle<
+        'a,
+        F: Future<Output = R> + 'a + Sync + Send,
+        R,
+    >(
+        &self,
+        f: F,
+    ) -> Result<SubTask<'a, R>, R> {
+        let mut st = self.start(f);
+        match st.run_until_idle().await {
+            Some(r) => Err(r),
+            None => Ok(st),
+        }
+    }
+
+    /// Waits for all tasks to be idle.
+    pub async fn wait_idle(&self) {
+        self.start_until_idle(smol::future::pending::<()>())
+            .await
+            .unwrap();
+    }
+}
+
+pub struct SubTask<'a, R> {
+    // See Sync+Send comment on `struct Task`
+    fut: Pin<Box<dyn Future<Output = R> + 'a + Sync + Send>>,
+    // Has a corresponding pender in StepExecutor's sub_tasks
+    pender: Arc<Pender>,
+
+    // Task is complete.
+    done: bool,
+}
+
+impl<R> core::fmt::Debug for SubTask<'_, R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubTask")
+            .field("pender", &self.pender)
+            .field("done", &self.done)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, R> SubTask<'a, R> {
+    /// Constructed via SubTaskList::start()
+    fn new<F: Future<Output = R> + 'a + Sync + Send>(
+        fut: F,
+        counter: Arc<AtomicU64>,
+    ) -> Self {
+        let fut = Box::pin(fut);
+        Self {
+            fut,
+            pender: Arc::new(Pender::new(counter)),
+            done: false,
+        }
+    }
+
+    /// Called by another task to progress this task, until all tasks go idle.
+    ///
+    /// Returns Some if the subtask completes, None otherwise.
+    ///
+    /// Panics if called after `SubTask` completion.
+    /// `StepExecutor` will later panic if `SubTask::run_until_idle`
+    /// is called from a different executor.
+    ///
+    /// Note: This may only be called by main tasks (ones started with
+    /// `StepExecutor::add()`). Subtasks will currently panic if they call
+    /// run_until_idle(). In future that could be added.
+    pub async fn run_until_idle(&mut self) -> Option<R> {
+        if self.done {
+            panic!("Can't run_until_idle() after completion");
+        }
+
+        poll_fn(|cx| {
+            self.pender.clear();
+            trace!("run_until_idle prepoll");
+            if let Poll::Ready(r) = self.fut.poll_unpin(cx) {
+                // The subtask completed
+                trace!("run_until_idle ready {:?}", cx.waker());
+                self.done = true;
+                return Poll::Ready(Some(r));
+            }
+
+            let (idle, idle_counter) = self
+                .pender
+                .with(|p| (p.subtask_idle, p.subtask_idle_counter));
+            let now = self.pender.read_counter();
+            if idle && idle_counter == now {
+                // All tasks were idle.
+                trace!("run_until_idle idle {:?}", cx.waker());
+                return Poll::Ready(None);
+            }
+            trace!("idle {idle:?} idle_counter {idle_counter} now {now}");
+
+            // StepExecutor will periodically uniquify the list TODO check.
+            trace!("run_until_idle push {:?}", cx.waker());
+            self.pender
+                .with(|p| p.subtask_idle_waiters.push(cx.waker().clone()));
+            Poll::Pending
+        })
+        .await
+    }
+}
+
+/// Poll the task's future to completion.
+impl<R> Future for SubTask<'_, R> {
+    type Output = R;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Self::Output> {
+        if self.done {
+            panic!("Can't await after completion");
+        }
+
+        self.pender.clear();
+        let r = self.fut.poll_unpin(cx);
+        self.done = r.is_ready();
+        r
+    }
+}
+
+/// Holds a pinned boxed future.
+///
+/// The future's output is discarded on completion.
+///
+/// TODO: Currently this has `Sync + Send` bounds (easier to relax later),
+/// but they're expected to run in a single threaded `StepExecutor` instance.
+/// Is there a use case for `Sync + Send` (sending to other executors?), or should
+/// the bounds be removed?
+struct Task<'a> {
+    fut: Pin<Box<dyn Future<Output = ()> + 'a + Sync + Send>>,
+}
+
+impl core::fmt::Debug for Task<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Task").finish_non_exhaustive()
+    }
+}
+
+impl<'a> Task<'a> {
+    fn new<F: Future<Output = R> + 'a + Sync + Send, R>(fut: F) -> Self {
+        // Convert the future to return ()
+        let fut = async {
+            fut.await;
+        };
+
+        let fut = Box::pin(fut);
+        Self { fut }
+    }
+}
+
+fn start_log() {
+    let _ = env_logger::Builder::new()
+        .filter(None, log::LevelFilter::Trace)
+        .is_test(true)
+        .try_init();
+}
+
+#[test]
+fn step_executor_1() {
+    start_log();
+
+    let mut ex = StepExecutor::default();
+    let (ex1_s, ex1_r) = smol::channel::bounded(1);
+    let (ex2_s, ex2_r) = smol::channel::bounded(1);
+    let (ex3_s, ex3_r) = smol::channel::bounded(1);
+    let (sub_s, sub_r) = smol::channel::bounded(1);
+
+    trace!("top");
+    ex.add(async move {
+        for i in 0..5 {
+            trace!("ex1 {i}");
+            smol::future::yield_now().await;
+        }
+        ex1_s.try_send(()).unwrap();
+
+        smol::future::pending::<()>().await;
+        unreachable!();
+    });
+
+    ex.add(async move {
+        for i in 0..10 {
+            trace!("ex2 {i}");
+            smol::future::yield_now().await;
+        }
+        ex2_s.try_send(()).unwrap();
+    });
+
+    let sub = ex.sub_runner();
+
+    ex.add(async move {
+        let f = async {
+            for i in 0..10 {
+                trace!("f {i}");
+                smol::future::yield_now().await;
+                smol::future::yield_now().await;
+                smol::future::yield_now().await;
+            }
+            sub_s.try_send(5).unwrap();
+            smol::future::pending::<u8>().await;
+        };
+
+        let mut f = sub.start(f);
+        match f.run_until_idle().await {
+            Some(r) => {
+                info!("sub wait result {r:?}");
+                panic!("No result should be returned");
+            }
+            None => info!("sub wait idle"),
+        }
+        ex3_s.try_send(()).unwrap();
+
+        // let t = ex.
+    });
+
+    assert!(ex1_r.try_recv().is_err());
+    assert!(ex2_r.try_recv().is_err());
+    assert!(ex3_r.try_recv().is_err());
+
+    ex.until_idle();
+
+    assert!(ex1_r.try_recv().is_ok());
+    assert!(ex2_r.try_recv().is_ok());
+    assert!(ex3_r.try_recv().is_ok());
+    assert!(sub_r.try_recv().is_ok());
+}
+
+#[test]
+fn step_executor_subtask_yield() {
+    start_log();
+
+    let mut ex = StepExecutor::default();
+    let (ex3_s, ex3_r) = smol::channel::bounded(1);
+
+    let sub = ex.sub_runner();
+
+    ex.add(async move {
+        let f = async {
+            for i in 0..10 {
+                trace!("f {i}");
+                smol::future::yield_now().await;
+                smol::future::yield_now().await;
+                smol::future::yield_now().await;
+            }
+            "the end."
+        };
+
+        let mut f = sub.start(f);
+        let r = f.run_until_idle().await;
+        assert_eq!(r, Some("the end."));
+        ex3_s.try_send(()).unwrap();
+    });
+
+    assert!(ex3_r.try_recv().is_err());
+
+    ex.until_idle();
+
+    assert!(ex3_r.try_recv().is_ok());
+}
+
+#[test]
+fn step_executor_subtask_pending() {
+    start_log();
+
+    let mut ex = StepExecutor::default();
+    let (ex3_s, ex3_r) = smol::channel::bounded(1);
+
+    let sub = ex.sub_runner();
+
+    ex.add(async move {
+        let f = async {
+            smol::future::yield_now().await;
+            smol::future::pending::<u32>().await
+        };
+
+        let mut f = sub.start(f);
+        let r = f.run_until_idle().await;
+        assert!(r.is_none());
+        ex3_s.try_send("done").unwrap();
+    });
+
+    assert!(ex3_r.try_recv().is_err());
+
+    ex.until_idle();
+
+    assert_eq!(ex3_r.try_recv(), Ok("done"))
+}
+
+#[test]
+fn step_executor_subtask_busy() {
+    start_log();
+
+    let mut ex = StepExecutor::default();
+
+    let sub = ex.sub_runner();
+
+    // Add an unrelated main task that is never idle
+    ex.add(async move {
+        for _ in 0..10 {
+            smol::future::yield_now().await;
+        }
+    });
+
+    ex.add(async move {
+        let f = async {
+            loop {
+                smol::future::yield_now().await;
+            }
+        };
+
+        let mut f = sub.start(f);
+        f.run_until_idle().await;
+        unreachable!()
+    });
+
+    let run = ex.until_idle_limit_iter(1000);
+    assert!(run.is_err(), "the subtask shouldn't return return");
+}
+
+#[test]
+fn step_executor_subtask_other_busy() {
+    start_log();
+
+    let mut ex = StepExecutor::default();
+
+    let sub = ex.sub_runner();
+
+    // Add an unrelated main task that is never idle
+    ex.add(async move {
+        loop {
+            smol::future::yield_now().await;
+        }
+    });
+
+    ex.add(async move {
+        let f = async {
+            for _ in 0..5 {
+                smol::future::yield_now().await;
+            }
+            "done"
+        };
+
+        let mut f = sub.start(f);
+        assert_eq!(f.run_until_idle().await, Some("done"));
+    });
+
+    let run = ex.until_idle_limit_iter(1000);
+    assert!(run.is_err(), "the first loop shouldn't return");
+}

--- a/mctp-linux/src/lib.rs
+++ b/mctp-linux/src/lib.rs
@@ -707,7 +707,7 @@ pub struct MctpLinuxAsyncResp<'l> {
     typ: MsgType,
 }
 
-impl<'l> mctp::AsyncRespChannel for MctpLinuxAsyncResp<'l> {
+impl mctp::AsyncRespChannel for MctpLinuxAsyncResp<'_> {
     type ReqChannel<'a>
         = MctpLinuxAsyncReq
     where

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -325,7 +325,7 @@ impl<const N: usize> TryFrom<&str> for AsciiString<N> {
     }
 }
 
-impl<'a, Predicate, const N: usize> DekuReader<'a, (Limit<u8, Predicate>, ())>
+impl<Predicate, const N: usize> DekuReader<'_, (Limit<u8, Predicate>, ())>
     for AsciiString<N>
 where
     Predicate: FnMut(&u8) -> bool,

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -203,7 +203,7 @@ pub struct PldmRequest<'a> {
     pub data: VecOrSlice<'a, u8>,
 }
 
-impl<'a> Debug for PldmRequest<'a> {
+impl Debug for PldmRequest<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let vs = match self.data {
             #[cfg(feature = "alloc")]
@@ -222,7 +222,7 @@ impl<'a> Debug for PldmRequest<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> PldmRequest<'a> {
+impl PldmRequest<'_> {
     /// Converts any `PldmRequest` into one with allocated storage
     pub fn make_owned(self) -> PldmRequest<'static> {
         let d = match self.data {
@@ -347,7 +347,7 @@ pub struct PldmResponse<'a> {
     pub data: VecOrSlice<'a, u8>,
 }
 
-impl<'a> Debug for PldmResponse<'a> {
+impl Debug for PldmResponse<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let vs = match self.data {
             #[cfg(feature = "alloc")]
@@ -367,7 +367,7 @@ impl<'a> Debug for PldmResponse<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> PldmResponse<'a> {
+impl PldmResponse<'_> {
     /// Set the data payload for this response
     pub fn set_data(&mut self, data: Vec<u8>) {
         self.data = data.into()

--- a/pldm/src/util.rs
+++ b/pldm/src/util.rs
@@ -21,14 +21,14 @@ pub enum VecOrSlice<'a, V> {
     Borrowed(&'a [V]),
 }
 
-impl<'a, V> core::ops::Deref for VecOrSlice<'a, V> {
+impl<V> core::ops::Deref for VecOrSlice<'_, V> {
     type Target = [V];
     fn deref(&self) -> &[V] {
         self.as_ref()
     }
 }
 
-impl<'a, V> AsRef<[V]> for VecOrSlice<'a, V> {
+impl<V> AsRef<[V]> for VecOrSlice<'_, V> {
     fn as_ref(&self) -> &[V] {
         match self {
             #[cfg(feature = "alloc")]

--- a/standalone/src/serial.rs
+++ b/standalone/src/serial.rs
@@ -31,8 +31,7 @@ struct Inner<S: Read + Write> {
 impl<S: Read + Write> Inner<S> {
     fn new(own_eid: Eid, serial: S) -> Self {
         let start_time = Instant::now();
-        let todo_mtu = 64;
-        let mctp = Stack::new(own_eid, todo_mtu, 0);
+        let mctp = Stack::new(own_eid, 0);
         let mctpserial = MctpSerialHandler::new();
         Self {
             mctp,


### PR DESCRIPTION
This series restructures `Router` and `PortTop`/`PortBottom` to have improved ownership/lifetimes, making it easier for using non-static. The impetus is for writing tests, but it should be useful in other situations too.

`RouterAsyncReqChannel`/`RouterAsyncListener` now can have a receive timeout set.

The `PortLookup` API is changed, now taking a const reference, and the MTU for an outgoing message is also taken from `PortLookup`.

 In order to use async closures for tests there is a bump to minimum Rust 1.85.