### PR TITLE
pldm-file, pldm-platform: CRC correctness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CodeConstruct/mctp-rs"
 anyhow = "1.0.80"
 argh = "0.1.12"
 chrono = { version = "0.4", default-features = false }
-crc = "3.0"
+crc = "3.3"
 defmt = "0.3"
 deku = { git = "https://github.com/CodeConstruct/deku.git", tag = "cc/deku-v0.19.1/no-alloc-3", default-features = false }
 embedded-io-adapters = { version = "0.6", features = ["std", "futures-03"] }

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -80,6 +80,9 @@ impl std::fmt::Display for PldmFileError {
     }
 }
 
+const CRC32: crc::Crc<u32, crc::Table<16>> =
+    crc::Crc::<u32, crc::Table<16>>::new(&crc::CRC_32_ISO_HDLC);
+
 type Result<T> = std::result::Result<T, PldmFileError>;
 
 impl<const N: usize> Responder<N> {
@@ -402,8 +405,8 @@ impl<const N: usize> Responder<N> {
         let data = &mut resp_data[l..];
         host.read(data, xfer_ctx.start + offset)
             .map_err(|_| CCode::ERROR)?;
-        let crc32 = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
-        let cs = crc32.checksum(data);
+
+        let cs = CRC32.checksum(data);
         resp_data.extend_from_slice(&cs.to_le_bytes());
 
         xfer_ctx.offset = offset;

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -369,8 +369,11 @@ impl<const N: usize> Responder<N> {
                 // a repeated FIRST_PART is valid, and restarts the transfer
                 ctx.reset();
             } else {
-                let new_ctx = Self::init_read(&cmd)?;
-                file_ctx.xfer_ctx.replace(new_ctx);
+                let ctx = FileTransferContext::new(
+                    cmd.req_offset as usize,
+                    cmd.req_length as usize,
+                );
+                file_ctx.xfer_ctx.replace(ctx);
             };
         }
 
@@ -431,15 +434,6 @@ impl<const N: usize> Responder<N> {
         resp.set_data(resp_data);
 
         Ok(resp)
-    }
-
-    fn init_read(
-        req: &pldm::control::MultipartReceiveReq,
-    ) -> Result<FileTransferContext> {
-        trace!("init_read {req:?}");
-        let start = req.req_offset as usize;
-        let len = req.req_length as usize;
-        Ok(FileTransferContext::new(start, len))
     }
 }
 

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -675,8 +675,7 @@ impl GetPDRResp {
             next_data_transfer_handle: 0,
             transfer_flag: xfer_flag::START_AND_END,
             record_data: Default::default(),
-            // TODO crc
-            crc: Some(0),
+            crc: None,
         };
         let cap = s.record_data.capacity();
         s.record_data.resize_default(cap).unwrap();


### PR DESCRIPTION
A few fixes from testing against other implementations:

 - PDR responses only have a CRC on end parts
 - DfRead CRC is cumulative over all parts