### PR TITLE
PLDM file buffer sizes and pldm-file-host usability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ name = "pldm-file"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argh",
  "chrono",
  "crc",
  "deku",

--- a/pldm-file/Cargo.toml
+++ b/pldm-file/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = { workspace = true }
 pldm = { workspace = true }
 
 [dev-dependencies]
+argh = { workspace = true }
 anyhow = "1.0"
 chrono = { workspace = true, features = ["clock"] }
 mctp-linux = { workspace = true }

--- a/pldm-file/examples/client.rs
+++ b/pldm-file/examples/client.rs
@@ -38,19 +38,21 @@ fn main() -> Result<()> {
 
         let mut buf = Vec::new();
         let req_len = 4096;
+        let mut part_buf = [0u8; 512 + 18];
 
         println!("Reading...");
-        let res = df_read_with(&mut req, fd, 0, req_len, |part| {
-            println!("  {} bytes", part.len());
-            if buf.len() + part.len() > req_len {
-                println!("  data overflow!");
-                Err(PldmError::NoSpace)
-            } else {
-                buf.extend_from_slice(part);
-                Ok(())
-            }
-        })
-        .await;
+        let res =
+            df_read_with(&mut req, fd, 0, req_len, &mut part_buf, |part| {
+                println!("  {} bytes", part.len());
+                if buf.len() + part.len() > req_len {
+                    println!("  data overflow!");
+                    Err(PldmError::NoSpace)
+                } else {
+                    buf.extend_from_slice(part);
+                    Ok(())
+                }
+            })
+            .await;
 
         println!("Read: {res:?}");
 

--- a/pldm-file/src/host.rs
+++ b/pldm-file/src/host.rs
@@ -15,7 +15,8 @@ use crate::PLDM_TYPE_FILE_TRANSFER;
 
 const FILE_ID: FileIdentifier = FileIdentifier(0);
 
-const MAX_PART_SIZE: u16 = 1024;
+// Largest possible power of two
+const MAX_PART_SIZE: u16 = 8192;
 
 pub trait Host {
     /// Returns number of bytes read


### PR DESCRIPTION
This allows running with larger part sizes for better performance.

pldm-file-host has some extra functionality to run with synthetic data when measuring speed.