### PR TITLE
pldm-file: client: send NEXT_PART requests with TransferContext set

### DIFF
--- a/pldm-file/src/client.rs
+++ b/pldm-file/src/client.rs
@@ -228,7 +228,6 @@ where
 
         part_offset = total_len;
         req.xfer_op = pldm::control::xfer_op::NEXT_PART;
-        req.xfer_context = 0;
         req.xfer_handle = read_resp.next_handle;
         req.req_offset = 0;
         req.req_length = 0;


### PR DESCRIPTION
Currently, we clear out the TransferContext field of NEXT_PART multipart receive commands, in line with handling for the offset and length fields (as required by the spec). However, hosts may be relying on the TransferContext for subsequent requests too, so don't clear that out for NEXT_PART reqs.