### PR TITLE
mctp-estack: I2C transport: Unit tests, fix surfaced bugs, small improvements and doc

### DIFF
--- a/mctp-estack/src/i2c.rs
+++ b/mctp-estack/src/i2c.rs
@@ -106,8 +106,10 @@ impl MctpI2cEncap {
 
         let header =
             MctpI2cHeader::decode(packet.get(..4).ok_or(Error::InvalidInput)?)?;
-        // +1 for i2c source address field
-        if header.byte_count != packet.len() + 1 {
+        // total packet len == byte_count + 3 (destination, command code, byte count)
+        // pec is not included
+        if header.byte_count + 3 != packet.len() {
+            trace!("Packet byte count mismatch");
             return Err(Error::InvalidInput);
         }
 

--- a/mctp-estack/src/i2c.rs
+++ b/mctp-estack/src/i2c.rs
@@ -104,7 +104,8 @@ impl MctpI2cEncap {
             }
         }
 
-        let header = MctpI2cHeader::decode(packet)?;
+        let header =
+            MctpI2cHeader::decode(packet.get(..4).ok_or(Error::InvalidInput)?)?;
         // +1 for i2c source address field
         if header.byte_count != packet.len() + 1 {
             return Err(Error::InvalidInput);

--- a/mctp-estack/src/i2c.rs
+++ b/mctp-estack/src/i2c.rs
@@ -63,8 +63,8 @@ impl MctpI2cHeader {
             return Err(Error::InvalidInput);
         }
         Ok(Self {
-            dest,
-            source,
+            dest: dest >> 1,
+            source: source >> 1,
             byte_count: byte_count as usize,
         })
     }

--- a/mctp-estack/src/i2c.rs
+++ b/mctp-estack/src/i2c.rs
@@ -90,11 +90,11 @@ impl MctpI2cEncap {
         mut packet: &'f [u8],
         pec: bool,
     ) -> Result<(&'f [u8], MctpI2cHeader)> {
+        if packet.is_empty() {
+            return Err(Error::InvalidInput);
+        }
         if pec {
             // Remove the pec byte, check it.
-            if packet.is_empty() {
-                return Err(Error::InvalidInput);
-            }
             let packet_pec;
             (packet_pec, packet) = packet.split_last().unwrap();
             let calc_pec = smbus_pec::pec(packet);


### PR DESCRIPTION
- Added some basic unit tests for the I2C codec
- Fixed a few bugs that surfaced when running the tests
  - The `MctpI2cHeader::decode()` function has to be called with only the 4-byte header (not the whole packet)
  - The _Byte Count_ header field was checked against the whole packet, which is 3 byte larger than the field (instead of only 1) 
  - Checking for empty packets (and returning early) was only done when _PEC_ check was activated
- Return the complete header when decoding a packet
- Remove the I2C / SMBus / IPMI specific bits from the address bytes when decoding the header
- Add _doc_ comments