### PR TITLE
Fix lint failures on nightly, don't run nightly on PRs

### DIFF
--- a/.github/workflows/nightly-daily.yml
+++ b/.github/workflows/nightly-daily.yml
@@ -1,0 +1,45 @@
+# Run CI with Rust nightly builds to notice breakage early.
+
+name: nightly-daily
+on:
+  schedule:
+  - cron: "8 20 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+          - rust_version: nightly
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Rust files
+        uses: actions/cache@v4
+        with:
+          # target/ci isn't cached since it will be expected to change every day
+          path: |
+            ~/.cargo/
+          # Save a unique cache each time
+          # (https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache)
+          key: rust-${{ matrix.rust_version }}-${{ github.run_id }}
+          # Load from the most recent match
+          restore-keys: |
+            rust-${{ matrix.rust_version }}
+
+      - name: Rustup ${{ matrix.rust_version }}
+        run: |
+          rustup update ${{ matrix.rust_version }}
+          rustup override set ${{ matrix.rust_version }}
+
+      - name: Build and test ${{ matrix.rust_version }}
+        env:
+          # Older clippy has some unwanted lints, ignore them.
+          NO_CLIPPY: ${{ matrix.no_clippy }}
+        run: ./ci/runtests.sh

--- a/pldm-fw/src/lib.rs
+++ b/pldm-fw/src/lib.rs
@@ -8,6 +8,10 @@
 #![forbid(unsafe_code)]
 // #![warn(missing_docs)]
 
+// collapsible_match lint suggests moving `if` statements into the parent
+// `match` arms, but that makes code intent less clear.
+#![allow(clippy::collapsible_match)]
+
 use core::fmt;
 use log::debug;
 

--- a/pldm-platform/src/proto.rs
+++ b/pldm-platform/src/proto.rs
@@ -431,7 +431,7 @@ impl<T: FromPrimitive + Debug> StateDebug<T> {
 impl<T: FromPrimitive + Debug> Debug for StateDebug<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(v) = T::from_u8(self.state) {
-            write!(f, "{} {:?}", self.state, &v)
+            write!(f, "{} {:?}", self.state, v)
         } else {
             write!(f, "{} (unrecognised state)", self.state)
         }

--- a/pldm/src/lib.rs
+++ b/pldm/src/lib.rs
@@ -60,7 +60,7 @@ impl core::fmt::Display for PldmError {
             Self::InvalidArgument => write!(f, "Invalid Argument"),
             Self::NoSpace => write!(f, "Insufficient buffer space available"),
             Self::CompletionCode(c) => {
-                write!(f, "Error completion code {c:#02x} received")
+                write!(f, "Error completion code 0x{c:02x} received")
             }
         }
     }


### PR DESCRIPTION
The Rust nightly job has been failing in PRs since some new lints were added.

Resolve those lints, and instead run the nightly PR in a cronjob so that we (maintainers) can see the problems without it being noise in PRs.