### PR TITLE
Fix nightly CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - rust_version: 1.85
             no_clippy: yes
 
-          - rust_version: nightly
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly-daily.yml
+++ b/.github/workflows/nightly-daily.yml
@@ -13,6 +13,7 @@ jobs:
   ci:
     strategy:
       matrix:
+        include:
           - rust_version: nightly
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a followup to #48 making it _really_ not run nightly for PRs, and fixing nightly.yml.