### PR TITLE
ci: fix timezone and hours/mins mixup for nightly

### DIFF
--- a/.github/workflows/nightly-daily.yml
+++ b/.github/workflows/nightly-daily.yml
@@ -3,7 +3,8 @@
 name: nightly-daily
 on:
   schedule:
-    - cron: "8 20 * * *"
+    - cron: "50 5 * * *"
+      timezone: "Australia/Perth"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The job was intended to run at 8:20AM Perth time, but was actually running at 20:08 UTC.

At the same time, adjust the time to be 2h30m earlier so it's also ready in the morning for Adelaide. (Australia/Adelaide timezone is not used since it is less stable with daylight saving).

Fixes: cfa4167d0a80 ("ci: build against Rust nightly separately to PRs")