### PR TITLE
mctp-linux: Depend on mctp "std" feature

### DIFF
--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -59,13 +59,20 @@ declare -a FEATURES=(
     "$FEATURES_ASYNC"
 )
 
-# mctp-estack, sync an async
+# mctp-estack, sync and async
 (
 cd mctp-estack
 for feature in "${FEATURES[@]}"; do
     cargo test --features="$feature"
 done;
 )
+
+# Linux programs and examples
+# Tested individually to ensure each defines necessary features itself
+LINUX_PROGRAMS="mctp-linux pldm-platform-util pldm-fw-cli mctp-standalone pldm-file pldm-platform"
+for c in $LINUX_PROGRAMS; do
+    cargo check -p $c --all-targets
+done
 
 # run cargo doc tests
 for feature in "${FEATURES[@]}"; do

--- a/mctp-linux/Cargo.toml
+++ b/mctp-linux/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "embedded", "hardware-support", "os::linux-
 
 [dependencies]
 libc = "0.2"
-mctp = { workspace = true }
+mctp = { workspace = true, features = ["std"] }
 smol = { workspace = true }
 
 [[example]]


### PR DESCRIPTION
Wasn't caught by CI because that checks all crates together and mctp/std
was pulled in by other crates.

Fixes: https://github.com/CodeConstruct/mctp-rs/commit/e46166d748c01a206a09c832c337718b748eb1c4 ("Put more dependencies in the top-level `Cargo.toml`.")